### PR TITLE
Board name change

### DIFF
--- a/app/(loggedin)/home/boards/page.tsx
+++ b/app/(loggedin)/home/boards/page.tsx
@@ -4,8 +4,9 @@ import Link from 'next/link';
 import { SlUser } from 'react-icons/sl';
 import { BsPencil } from 'react-icons/bs';
 import { useRouter } from 'next/navigation';
-import { ChangeEvent, useRef, useEffect, useState } from 'react';
+import { ChangeEvent, useEffect, useState } from 'react';
 
+import { cn } from '@/lib/utils';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { useAppSelector, useAppDispatch } from '@/redux/hooks';
@@ -24,7 +25,6 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog';
-import { cn } from '@/lib/utils';
 
 const UserBoards = () => {
   const router = useRouter();
@@ -32,33 +32,22 @@ const UserBoards = () => {
   const user = localStorage.getItem('user');
   const email = user ? JSON.parse(user).email : '';
   const [isEditing, setIsEditing] = useState(false);
-  const [currentBoardId, setCurrentBoardId] = useState('');
   const [newBoardName, setNewBoardName] = useState('');
   const accessToken = localStorage.getItem('accessToken');
-  const [renamedBoardName, setRenamedBoardName] = useState('new name');
+  const [currentBoardId, setCurrentBoardId] = useState('');
+  const [renamedBoardName, setRenamedBoardName] = useState('');
   const [buttonIsDisabled, setButtonIsDisabled] = useState(true);
   const { boards, boardsStatus } = useAppSelector((state) => state.boards);
-
-  const inputElement = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (boardsStatus === 'succeeded') {
       dispatch(getBoards(accessToken as string));
     }
-  }, [dispatch, accessToken]);
-
-  // const submitForm = (event: React.FormEvent<HTMLFormElement>) => {
-  //   event.preventDefault();
-  //   console.log('Form submitted');
-
-  //   // TODO: Implement board name change functionality
-  //   // TODO: Update the board name in the database
-  // };
+  }, [dispatch, accessToken, boardsStatus]);
 
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     e.preventDefault();
     setNewBoardName(e.target.value);
-    console.log('newBoardName: ', newBoardName);
     setButtonIsDisabled(e.target.value === '');
   };
 
@@ -73,7 +62,6 @@ const UserBoards = () => {
   useEffect(() => {
     if (isEditing) {
       const currentInputElement = document.getElementById(currentBoardId);
-      console.log('currentInputElement: ', currentInputElement);
       if (currentBoardId === currentInputElement!.id) {
         currentInputElement!.focus();
         currentInputElement!.select();
@@ -81,10 +69,7 @@ const UserBoards = () => {
     }
   }, [isEditing, currentBoardId]);
 
-  const handleBoardNameChange = (
-    e: ChangeEvent<HTMLInputElement>,
-    id: string
-  ) => {
+  const handleBoardNameChange = (e: ChangeEvent<HTMLInputElement>) => {
     e.preventDefault();
     setRenamedBoardName(e.target.value);
   };
@@ -117,52 +102,47 @@ const UserBoards = () => {
       </div>
       <div className="mt-8 grid grid-cols-1 lg:grid-cols-2 2xl:grid-cols-3 gap-4">
         {boards.map((board) => (
-          // <Link
-          //   href={`/home/boards/${board.id}/board`}
-          //   key={board.id}
-          //   className={cn(
-          //     isEditing ? 'pointer-events-none border-2 border-blue-500' : '',
-          //     'border rounded-sm px-6 py-5 flex items-center justify-center h-[160px]'
-          //   )}
-          //   title="board name"
-          // >
-          <div className="relative w-full h-full" key={board.id}>
-            <BsPencil
-              z-index={1000}
-              className="absolute top-0 right-0"
-              onClick={(e) => {
-                e.preventDefault();
-                setIsEditing(true);
-                setCurrentBoardId(board.id);
-                setRenamedBoardName(board.name);
-              }}
-            />
-            {isEditing && currentBoardId === board.id ? (
-              // <form onSubmit={submitForm}>
-              <Input
-                ref={inputElement}
-                id={board.id}
-                placeholder="Board name (e.g., Job Search 2024)"
-                value={renamedBoardName}
-                // type="submit"
-                // onChange={(e) => console.log('Event: ', e.target.value)}
-                onChange={(e) => handleBoardNameChange(e, board.id)}
-                onKeyDown={(e) => checkForEnter(e)}
-                // onChange={(e) => setRenamedBoardName(e.target.value)}
-                onBlur={confirmBoardNameChange}
-                className="focus:border-blue-500"
-              />
-            ) : (
-              // </form>
-              <p className="text-lg font-semibold">{board.name}</p>
+          <Link
+            href={`/home/boards/${board.id}/board`}
+            key={board.id}
+            className={cn(
+              isEditing ? 'pointer-events-none border-2 border-blue-500' : '',
+              'border rounded-sm px-6 py-5 flex items-center justify-center h-[160px]'
             )}
-            {/* Bellow line is the user's name, which we do not have so far */}
-            {/* TODO: Resolve the issue with user's name! */}
-            {/* <p className="text-slate-700 text-sm">{board.label}</p> */}
-            <p className="text-slate-400 text-xs">{email}</p>
-            {/* TODO: Created at or how many days/weeks/months ago? */}
-          </div>
-          // </Link>
+            title="board name"
+          >
+            <div className="relative w-full h-full">
+              <BsPencil
+                z-index={1000}
+                className="absolute top-0 right-0"
+                onClick={(e) => {
+                  e.preventDefault();
+                  setIsEditing(true);
+                  setCurrentBoardId(board.id);
+                  setRenamedBoardName(board.name);
+                }}
+              />
+              {isEditing && currentBoardId === board.id ? (
+                <Input
+                  id={board.id}
+                  placeholder="Board name (e.g., Job Search 2024)"
+                  value={renamedBoardName}
+                  type="text"
+                  onChange={(e) => handleBoardNameChange(e)}
+                  onKeyDown={(e) => checkForEnter(e)}
+                  onBlur={confirmBoardNameChange}
+                  className="focus:border-blue-500"
+                />
+              ) : (
+                <p className="text-lg font-semibold">{board.name}</p>
+              )}
+              {/* Bellow line is the user's name, which we do not have so far */}
+              {/* TODO: Resolve the issue with user's name! */}
+              {/* <p className="text-slate-700 text-sm">{board.label}</p> */}
+              <p className="text-slate-400 text-xs">{email}</p>
+              {/* TODO: Created at or how many days/weeks/months ago? */}
+            </div>
+          </Link>
         ))}
         <div className="border rounded-sm px-6 py-5 flex items-center justify-center h-[160px]">
           <Dialog>

--- a/app/(loggedin)/home/boards/page.tsx
+++ b/app/(loggedin)/home/boards/page.tsx
@@ -36,7 +36,7 @@ const UserBoards = () => {
     if (boardsStatus === 'succeeded') {
       dispatch(getBoards(accessToken as string));
     }
-  }, [dispatch, accessToken]);
+  }, [dispatch, accessToken, boardsStatus]);
 
   const submitForm = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();

--- a/app/(loggedin)/home/boards/page.tsx
+++ b/app/(loggedin)/home/boards/page.tsx
@@ -43,7 +43,7 @@ const UserBoards = () => {
     if (boardsStatus === 'succeeded') {
       dispatch(getBoards(accessToken as string));
     }
-  }, [dispatch, accessToken, boardsStatus]);
+  }, [dispatch, accessToken]);
 
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     e.preventDefault();

--- a/app/(loggedin)/home/boards/page.tsx
+++ b/app/(loggedin)/home/boards/page.tsx
@@ -3,40 +3,22 @@
 import Link from 'next/link';
 import { SlUser } from 'react-icons/sl';
 import { BsPencil } from 'react-icons/bs';
-import { useRouter } from 'next/navigation';
 import { ChangeEvent, useEffect, useState } from 'react';
 
 import { cn } from '@/lib/utils';
 import { Input } from '@/components/ui/input';
-import { Button } from '@/components/ui/button';
 import { useAppSelector, useAppDispatch } from '@/redux/hooks';
-import {
-  createBoard,
-  getBoards,
-  renameBoard,
-} from '@/redux/boards/boardsThunk';
-import {
-  Dialog,
-  DialogClose,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/dialog';
+import { getBoards, renameBoard } from '@/redux/boards/boardsThunk';
+import CreateNewBoard from '@/components/HomePage/Boards/CreateNewBoard';
 
 const UserBoards = () => {
-  const router = useRouter();
   const dispatch = useAppDispatch();
   const user = localStorage.getItem('user');
   const email = user ? JSON.parse(user).email : '';
   const [isEditing, setIsEditing] = useState(false);
-  const [newBoardName, setNewBoardName] = useState('');
   const accessToken = localStorage.getItem('accessToken');
   const [currentBoardId, setCurrentBoardId] = useState('');
   const [renamedBoardName, setRenamedBoardName] = useState('');
-  const [buttonIsDisabled, setButtonIsDisabled] = useState(true);
   const { boards, boardsStatus } = useAppSelector((state) => state.boards);
 
   useEffect(() => {
@@ -44,20 +26,6 @@ const UserBoards = () => {
       dispatch(getBoards(accessToken as string));
     }
   }, [dispatch, accessToken]);
-
-  const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
-    e.preventDefault();
-    setNewBoardName(e.target.value);
-    setButtonIsDisabled(e.target.value === '');
-  };
-
-  const createNewBoard = async () => {
-    const name = newBoardName;
-    const values = { name, accessToken };
-    dispatch(createBoard(values));
-    router.push('/home/boards/');
-    newBoardName && setNewBoardName('');
-  };
 
   useEffect(() => {
     if (isEditing) {
@@ -145,49 +113,7 @@ const UserBoards = () => {
           </Link>
         ))}
         <div className="border rounded-sm px-6 py-5 flex items-center justify-center h-[160px]">
-          <Dialog>
-            <DialogTrigger asChild>
-              <Button variant="outline">+ New Board</Button>
-            </DialogTrigger>
-            <DialogContent className="sm:max-w-[425px]">
-              <DialogHeader className="pb-2">
-                <DialogTitle className="mx-auto">New Board</DialogTitle>
-                <DialogDescription className="border-t pt-4">
-                  <span className="flex flex-col py-4 bg-yellow-200 rounded-md">
-                    <span className="font-semibold px-4">
-                      Are you sure you want to create a new board?
-                    </span>
-                    <span className="px-4">
-                      We suggest having only one board per job search throughout
-                      your career.
-                    </span>
-                  </span>
-                </DialogDescription>
-              </DialogHeader>
-              <div className="flex">
-                <Input
-                  id="name"
-                  placeholder="Board name (e.g., Job Search 2024)"
-                  value={newBoardName}
-                  onChange={(e) => handleInputChange(e)}
-                  className="focus:border-blue-500"
-                />
-              </div>
-              <DialogFooter className="w-full">
-                <DialogClose asChild>
-                  <Button
-                    type="submit"
-                    variant="normal"
-                    className="w-full"
-                    disabled={buttonIsDisabled}
-                    onClick={createNewBoard}
-                  >
-                    Create Board
-                  </Button>
-                </DialogClose>
-              </DialogFooter>
-            </DialogContent>
-          </Dialog>
+          <CreateNewBoard buttonLabel="New Board" />
         </div>
       </div>
     </div>

--- a/components/HomePage/Boards/CreateNewBoard.tsx
+++ b/components/HomePage/Boards/CreateNewBoard.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { ChangeEvent, useState } from 'react';
+
+import { cn } from '@/lib/utils';
+import { Input } from '@/components/ui/input';
+import { useAppDispatch } from '@/redux/hooks';
+import { Button } from '@/components/ui/button';
+import { createBoard } from '@/redux/boards/boardsThunk';
+import { AlertDialogFooter } from '@/components/ui/alert-dialog';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+
+const CreateNewBoard = ({
+  buttonLabel,
+  styling,
+}: {
+  buttonLabel?: string;
+  styling?: string;
+}) => {
+  const dispatch = useAppDispatch();
+  const router = useRouter();
+  const [newBoardName, setNewBoardName] = useState('');
+  const [buttonIsDisabled, setButtonIsDisabled] = useState(true);
+  const accessToken = localStorage.getItem('accessToken');
+
+  const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+    e.preventDefault();
+    setNewBoardName(e.target.value);
+    setButtonIsDisabled(e.target.value === '');
+  };
+
+  const createNewBoard = async () => {
+    const name = newBoardName;
+    const values = { name, accessToken };
+    dispatch(createBoard(values));
+    router.push('/home/boards/');
+    newBoardName && setNewBoardName('');
+  };
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button variant="outline" className={cn(styling)}>
+          + {buttonLabel}
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader className="pb-2">
+          <DialogTitle className="mx-auto">New Board</DialogTitle>
+          <DialogDescription className="border-t pt-4">
+            <span className="flex flex-col py-4 bg-yellow-200 rounded-md">
+              <span className="font-semibold px-4">
+                Are you sure you want to create a new board?
+              </span>
+              <span className="px-4">
+                We suggest having only one board per job search throughout your
+                career.
+              </span>
+            </span>
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex">
+          <Input
+            id="name"
+            placeholder="Board name (e.g., Job Search 2024)"
+            value={newBoardName}
+            onChange={(e) => handleInputChange(e)}
+            className="focus:border-blue-500"
+          />
+        </div>
+        <AlertDialogFooter className="w-full">
+          <DialogClose asChild>
+            <Button
+              type="submit"
+              variant="normal"
+              className="w-full"
+              disabled={buttonIsDisabled}
+              onClick={createNewBoard}
+            >
+              Create Board
+            </Button>
+          </DialogClose>
+        </AlertDialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default CreateNewBoard;

--- a/components/HomePage/HomeNavbar/ComboBox.tsx
+++ b/components/HomePage/HomeNavbar/ComboBox.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { useState } from 'react';
+import { useParams } from 'next/navigation';
 import { CaretSortIcon, CheckIcon } from '@radix-ui/react-icons';
 
 import { cn } from '@/lib/utils';
@@ -22,9 +23,11 @@ import {
 } from '@/components/ui/command';
 
 export function ComboBox({ items, searchItem, initialString }: ComboBoxProps) {
+  const { board_id } = useParams();
   const [value, setValue] = useState('');
   const [open, setOpen] = useState(false);
   const { boardsStatus } = useAppSelector((state) => state.boards);
+  const currentBoardName = items.find((item) => item.id === board_id)?.name;
 
   return (
     boardsStatus === 'succeeded' && (
@@ -36,12 +39,7 @@ export function ComboBox({ items, searchItem, initialString }: ComboBoxProps) {
             aria-expanded={open}
             className="w-fit justify-between"
           >
-            {initialString !== ''
-              ? initialString
-              : value
-              ? items.find((item) => item.name === value)?.name
-              : `${items[0].name}`}{' '}
-            {/* This line is the default value and when 2 or more boards it is not correct! TODO: Must be fixed! */}
+            {currentBoardName}{' '}
             <CaretSortIcon className="ml-2 h-4 w-4 shrink-0 opacity-50" />
           </Button>
         </PopoverTrigger>
@@ -56,8 +54,8 @@ export function ComboBox({ items, searchItem, initialString }: ComboBoxProps) {
               <CommandGroup>
                 {items.map((item) => (
                   <CommandItem
-                    key={item.name}
-                    value={item.id}
+                    key={item.id}
+                    value={item.name}
                     onSelect={() => {
                       setValue(item.name);
                       setOpen(false);

--- a/components/HomePage/SideBar/JobBoardTitle.tsx
+++ b/components/HomePage/SideBar/JobBoardTitle.tsx
@@ -1,9 +1,13 @@
 import Link from 'next/link';
 import { useState } from 'react';
+import { useParams } from 'next/navigation';
 import { RiAccountPinBoxLine, RiDeleteBinLine } from 'react-icons/ri';
+
+import { cn } from '@/lib/utils';
 
 const JobBoardTitle = (board: Board) => {
   const [showTrash, setShowTrash] = useState(false);
+  const { board_id } = useParams();
 
   const toggleTrashIcon = () => {
     setTimeout(() => {
@@ -16,8 +20,12 @@ const JobBoardTitle = (board: Board) => {
       onMouseEnter={toggleTrashIcon}
       onMouseLeave={toggleTrashIcon}
       key={board.id}
-      className="flex justify-between items-center border border-slate-400 rounded-md bg-slate-200 p-2 mt-4 mx-2 cursor-pointer
-        dark:bg-slate-700 dark:border-slate-500 dark:text-white"
+      className={cn(
+        board_id === board.id
+          ? 'bg-blue-100 hover:bg-blue-100'
+          : 'hover:bg-slate-100',
+        'flex justify-between items-center p-2 mt-4 mx-2 rounded-md cursor-pointer'
+      )}
     >
       <div className="flex items-center gap-1">
         <RiAccountPinBoxLine className="h-5 w-5" />

--- a/components/HomePage/SideBar/JobTrackers.tsx
+++ b/components/HomePage/SideBar/JobTrackers.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
-import { RiAddBoxLine, RiQuestionMark } from 'react-icons/ri';
+import { RiQuestionMark } from 'react-icons/ri';
 
+import CreateNewBoard from '../Boards/CreateNewBoard';
 import {
   Tooltip,
   TooltipContent,
@@ -29,9 +30,12 @@ const JobTrackers = () => {
           </Tooltip>
         </TooltipProvider>
       </div>
-      {/* <div className="mr-2 cursor-pointer">
-        <RiAddBoxLine className="h-5 w-5 hover:transform hover:scale-110 transition duration-300 delay-100" />
-      </div> */}
+      <div className="mr-2 cursor-pointer">
+        <CreateNewBoard
+          buttonLabel=""
+          styling="max-w-0 max-h-0 p-3 font-bold"
+        />
+      </div>
     </div>
   );
 };

--- a/redux/boards/boardsSlice.ts
+++ b/redux/boards/boardsSlice.ts
@@ -1,7 +1,7 @@
 import { createSlice } from '@reduxjs/toolkit';
 
 import { RootState } from '../store';
-import { getBoards, createBoard } from './boardsThunk';
+import { getBoards, createBoard, renameBoard } from './boardsThunk';
 
 interface BoardsState {
   boards: Board[];
@@ -44,6 +44,20 @@ export const boardsSlice = createSlice({
       .addCase(createBoard.rejected, (state, action) => {
         state.boardsStatus = 'failed';
         state.error = action.error.message || 'Failed to create board';
+      })
+      .addCase(renameBoard.pending, (state) => {
+        state.boardsStatus = 'loading';
+      })
+      .addCase(renameBoard.fulfilled, (state, action) => {
+        state.boardsStatus = 'succeeded';
+        state.boards = state.boards.map((board) =>
+          board.id === action.payload.id ? action.payload : board
+        );
+        state.error = null;
+      })
+      .addCase(renameBoard.rejected, (state, action) => {
+        state.boardsStatus = 'failed';
+        state.error = action.error.message || 'Failed to rename board';
       });
   },
 });

--- a/redux/boards/boardsThunk.ts
+++ b/redux/boards/boardsThunk.ts
@@ -48,3 +48,25 @@ export const createBoard = createAsyncThunk(
     }
   }
 );
+
+export const renameBoard = createAsyncThunk(
+  'boards/renameBoard',
+  async (values: any, thunkAPI) => {
+    const { accessToken, name, id } = values;
+    const putData = { name };
+    try {
+      const res = await client.patch(`/boards/${id}`, putData, {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      const data = res.data;
+      return data;
+    } catch (err: any) {
+      return thunkAPI.rejectWithValue(
+        err.response?.data || 'Error renaming board'
+      );
+    }
+  }
+);

--- a/redux/boards/boardsThunk.ts
+++ b/redux/boards/boardsThunk.ts
@@ -53,9 +53,9 @@ export const renameBoard = createAsyncThunk(
   'boards/renameBoard',
   async (values: any, thunkAPI) => {
     const { accessToken, name, id } = values;
-    const putData = { name };
+    const patchData = { name };
     try {
-      const res = await client.patch(`/boards/${id}`, putData, {
+      const res = await client.patch(`/boards/${id}`, patchData, {
         headers: {
           Authorization: `Bearer ${accessToken}`,
         },


### PR DESCRIPTION
Add renameBoard action to the board thunk and slice.
Implement BoardName change.
Fix the boardName shown in the ComboBox in the HomeNavbar to correspond to the current board selected from the Sidebar.
Extract CreateNewBoard as a separate component and add the button in the SideBar along with the boards' page.
Implement selective highlight of the current board name in the SideBar.
