### PR TITLE
Delete board

### DIFF
--- a/app/(loggedin)/layout.tsx
+++ b/app/(loggedin)/layout.tsx
@@ -25,7 +25,7 @@ const HomeLayout = ({ children }: { children: React.ReactNode }) => {
 
   return (
     <div className="flex h-full">
-      <aside className="min-w-52">
+      <aside className="min-w-56">
         <Sidebar />
       </aside>
       {accessToken && (

--- a/app/(loggedin)/layout.tsx
+++ b/app/(loggedin)/layout.tsx
@@ -3,9 +3,9 @@
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 
-import { useAppDispatch, useAppSelector } from '@/redux/hooks';
 import { getBoards } from '@/redux/boards/boardsThunk';
 import Sidebar from '@/components/HomePage/SideBar/Sidebar';
+import { useAppDispatch, useAppSelector } from '@/redux/hooks';
 
 const HomeLayout = ({ children }: { children: React.ReactNode }) => {
   const router = useRouter();

--- a/components/HomePage/Boards/AlertDialogModal.tsx
+++ b/components/HomePage/Boards/AlertDialogModal.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+import { cn } from '@/lib/utils';
+
+const AlertDialogModal = ({
+  buttonLabel,
+  dialogTitle,
+  dialogText,
+  buttonCancel,
+  buttonConfirm,
+  actionFunction,
+  stylings,
+}: AlertDialogProps) => {
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button variant="outline" className={cn(stylings)}>
+          {buttonLabel}
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{dialogTitle}</AlertDialogTitle>
+          <AlertDialogDescription>{dialogText}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>{buttonCancel}</AlertDialogCancel>
+          <AlertDialogAction onClick={actionFunction}>
+            {buttonConfirm}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+};
+
+export default AlertDialogModal;

--- a/components/HomePage/HomeNavbar/ComboBox.tsx
+++ b/components/HomePage/HomeNavbar/ComboBox.tsx
@@ -22,7 +22,7 @@ import {
   CommandList,
 } from '@/components/ui/command';
 
-export function ComboBox({ items, searchItem, initialString }: ComboBoxProps) {
+export function ComboBox({ items, searchItem }: ComboBoxProps) {
   const { board_id } = useParams();
   const [value, setValue] = useState('');
   const [open, setOpen] = useState(false);

--- a/components/HomePage/SideBar/JobBoardTitle.tsx
+++ b/components/HomePage/SideBar/JobBoardTitle.tsx
@@ -1,13 +1,12 @@
 import Link from 'next/link';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useParams, useRouter, usePathname } from 'next/navigation';
 import { RiAccountPinBoxLine, RiDeleteBinLine } from 'react-icons/ri';
 
 import { cn } from '@/lib/utils';
+import { useAppDispatch, useAppSelector } from '@/redux/hooks';
 import { archiveBoard, getBoards } from '@/redux/boards/boardsThunk';
 import AlertDialogModal from '@/components/HomePage/Boards/AlertDialogModal';
-import { useAppDispatch, useAppSelector } from '@/redux/hooks';
-import Loader from '@/components/Misc/Loader';
 
 const JobBoardTitle = (board: Board) => {
   const dispatch = useAppDispatch();
@@ -25,16 +24,11 @@ const JobBoardTitle = (board: Board) => {
   };
 
   const handleArchiveBoard = (accessToken: string, boardId: string) => {
-    if (pathName === `/home/boards`) {
-      dispatch(archiveBoard({ accessToken, id: boardId }));
-      setTimeout(() => {
-        dispatch(getBoards(accessToken));
-      }, 2000);
-      router.push('/home/boards');
-      return;
-    }
-    if (boards.length === 1 || board_id === boardId) {
-      console.log('Deleting the last board or the current board');
+    if (
+      pathName === `/home/boards` ||
+      boards.length === 1 ||
+      board_id === boardId
+    ) {
       dispatch(archiveBoard({ accessToken, id: boardId }));
       setTimeout(() => {
         dispatch(getBoards(accessToken));

--- a/components/HomePage/SideBar/JobBoardTitle.tsx
+++ b/components/HomePage/SideBar/JobBoardTitle.tsx
@@ -1,18 +1,54 @@
 import Link from 'next/link';
-import { useState } from 'react';
-import { useParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { useParams, useRouter, usePathname } from 'next/navigation';
 import { RiAccountPinBoxLine, RiDeleteBinLine } from 'react-icons/ri';
 
 import { cn } from '@/lib/utils';
+import { archiveBoard, getBoards } from '@/redux/boards/boardsThunk';
+import AlertDialogModal from '@/components/HomePage/Boards/AlertDialogModal';
+import { useAppDispatch, useAppSelector } from '@/redux/hooks';
+import Loader from '@/components/Misc/Loader';
 
 const JobBoardTitle = (board: Board) => {
+  const dispatch = useAppDispatch();
+  const pathName = usePathname();
+  const router = useRouter();
+  const accessToken = localStorage.getItem('accessToken');
   const [showTrash, setShowTrash] = useState(false);
   const { board_id } = useParams();
+  const { boards } = useAppSelector((state) => state.boards);
 
   const toggleTrashIcon = () => {
     setTimeout(() => {
       setShowTrash((prev) => !prev);
     }, 300);
+  };
+
+  const handleArchiveBoard = (accessToken: string, boardId: string) => {
+    if (pathName === `/home/boards`) {
+      dispatch(archiveBoard({ accessToken, id: boardId }));
+      setTimeout(() => {
+        dispatch(getBoards(accessToken));
+      }, 2000);
+      router.push('/home/boards');
+      return;
+    }
+    if (boards.length === 1 || board_id === boardId) {
+      console.log('Deleting the last board or the current board');
+      dispatch(archiveBoard({ accessToken, id: boardId }));
+      setTimeout(() => {
+        dispatch(getBoards(accessToken));
+      }, 2000);
+      router.push('/home/boards');
+      return;
+    } else {
+      console.log('Deleting a different board, staying on the same page');
+      dispatch(archiveBoard({ accessToken, id: boardId }));
+      setTimeout(() => {
+        dispatch(getBoards(accessToken));
+      }, 2000);
+      router.push(pathName);
+    }
   };
 
   return (
@@ -27,13 +63,30 @@ const JobBoardTitle = (board: Board) => {
         'flex justify-between items-center p-2 mt-4 mx-2 rounded-md cursor-pointer'
       )}
     >
-      <div className="flex items-center gap-1">
-        <RiAccountPinBoxLine className="h-5 w-5" />
-        <Link href={`/home/boards/${board.id}/board`}>
+      <div className="">
+        <Link
+          href={`/home/boards/${board.id}/board`}
+          className="flex items-center gap-1"
+        >
+          <RiAccountPinBoxLine className="h-5 w-5" />
           <p>{board.name}</p>
         </Link>
       </div>
-      <div>{showTrash ? <RiDeleteBinLine className="h-5 w-5" /> : null}</div>
+      <div>
+        {showTrash ? (
+          <RiDeleteBinLine className="h-5 w-5 absolute m-2" />
+        ) : null}
+        <AlertDialogModal
+          stylings={cn('opacity-0')}
+          dialogTitle="Archive Board"
+          dialogText="Are you sure you want to archive this board?"
+          buttonConfirm="Archive"
+          buttonCancel="Cancel"
+          actionFunction={() =>
+            handleArchiveBoard(accessToken as string, board.id)
+          }
+        />
+      </div>
     </div>
   );
 };

--- a/components/HomePage/SideBar/JobBoardTitle.tsx
+++ b/components/HomePage/SideBar/JobBoardTitle.tsx
@@ -52,20 +52,18 @@ const JobBoardTitle = (board: Board) => {
       key={board.id}
       className={cn(
         board_id === board.id
-          ? 'bg-blue-100 hover:bg-blue-100'
+          ? 'bg-blue-100 hover:bg-blue-100 font-semibold'
           : 'hover:bg-slate-100',
-        'flex justify-between items-center p-2 mt-4 mx-2 rounded-md cursor-pointer'
+        'flex justify-between items-center mx-2 my-1 rounded-md cursor-pointer'
       )}
     >
-      <div className="">
-        <Link
-          href={`/home/boards/${board.id}/board`}
-          className="flex items-center gap-1"
-        >
-          <RiAccountPinBoxLine className="h-5 w-5" />
-          <p>{board.name}</p>
-        </Link>
-      </div>
+      <Link
+        href={`/home/boards/${board.id}/board`}
+        className="flex items-center gap-1 p-2 w-full"
+      >
+        <RiAccountPinBoxLine className="h-5 w-5" />
+        <p className="pr-20px">{board.name}</p>
+      </Link>
       <div>
         {showTrash ? (
           <RiDeleteBinLine className="h-5 w-5 absolute m-2" />

--- a/components/HomePage/SideBar/JobTrackers.tsx
+++ b/components/HomePage/SideBar/JobTrackers.tsx
@@ -11,7 +11,7 @@ import {
 
 const JobTrackers = () => {
   return (
-    <div className="flex justify-between items-center pl-4 mt-4">
+    <div className="flex justify-between items-center pl-4 my-4">
       <div className="flex items-center gap-1">
         <p className="hover:underline mr-1">
           <Link href="/home/boards">My Job Tracker</Link>

--- a/components/HomePage/SideBar/Sidebar.tsx
+++ b/components/HomePage/SideBar/Sidebar.tsx
@@ -15,7 +15,7 @@ const Sidebar = () => {
           <SideBarMenuItem linkName="Contacts" icon={<RiContactsLine />} />
           <SideBarMenuItem linkName="Documents" icon={<RiFolder2Line />} />
         </div>
-        <div className="border-b border-slate-200 h-[120px]">
+        <div className="border-b border-slate-200 h-auto pb-6">
           <JobTrackers />
           <JobBoard />
         </div>

--- a/redux/boards/boardsSlice.ts
+++ b/redux/boards/boardsSlice.ts
@@ -1,7 +1,12 @@
 import { createSlice } from '@reduxjs/toolkit';
 
 import { RootState } from '../store';
-import { getBoards, createBoard, renameBoard } from './boardsThunk';
+import {
+  getBoards,
+  createBoard,
+  renameBoard,
+  archiveBoard,
+} from './boardsThunk';
 
 interface BoardsState {
   boards: Board[];
@@ -58,6 +63,20 @@ export const boardsSlice = createSlice({
       .addCase(renameBoard.rejected, (state, action) => {
         state.boardsStatus = 'failed';
         state.error = action.error.message || 'Failed to rename board';
+      })
+      .addCase(archiveBoard.pending, (state) => {
+        state.boardsStatus = 'loading';
+      })
+      .addCase(archiveBoard.fulfilled, (state, action) => {
+        state.boardsStatus = 'succeeded';
+        state.boards = state.boards.map((board) =>
+          board.id === action.payload.id ? action.payload : board
+        );
+        state.error = null;
+      })
+      .addCase(archiveBoard.rejected, (state, action) => {
+        state.boardsStatus = 'failed';
+        state.error = action.error.message || 'Failed to archive board';
       });
   },
 });

--- a/redux/boards/boardsThunk.ts
+++ b/redux/boards/boardsThunk.ts
@@ -75,3 +75,30 @@ export const renameBoard = createAsyncThunk(
     }
   }
 );
+
+export const archiveBoard = createAsyncThunk(
+  'boards/archiveBoard',
+  async (values: any, thunkAPI) => {
+    const { accessToken, id } = values;
+    try {
+      const res = await client.patch(
+        `/boards/${id}`,
+        {
+          isArchived: true,
+        },
+        {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        }
+      );
+
+      const data = res.data;
+      return data;
+    } catch (err: any) {
+      return thunkAPI.rejectWithValue(
+        err.response?.data || 'Error archiving board'
+      );
+    }
+  }
+);

--- a/redux/boards/boardsThunk.ts
+++ b/redux/boards/boardsThunk.ts
@@ -17,7 +17,12 @@ export const getBoards = createAsyncThunk(
         return thunkAPI.rejectWithValue('No boards found');
       }
 
-      return data;
+      // return only the boards that have isArchived set to false
+
+      if (data.length > 0) {
+        const filteredData = data.filter((board: any) => !board.isArchived);
+        return filteredData;
+      }
     } catch (err: any) {
       console.log('Error fetching boards: ', err.response?.data);
       return thunkAPI.rejectWithValue(

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -37,3 +37,13 @@ interface LinkDocumentProps {
   searchItem: string;
   initialString: string;
 }
+
+interface AlertDialogProps {
+  buttonLabel?: React.ReactNode;
+  dialogTitle: string;
+  dialogText: string;
+  buttonConfirm: string;
+  buttonCancel: string;
+  actionFunction: () => void;
+  stylings?: string;
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -29,7 +29,7 @@ interface WorkDocument {
 interface ComboBoxProps {
   items: Board[];
   searchItem: string;
-  initialString: string;
+  initialString?: string;
 }
 
 interface LinkDocumentProps {


### PR DESCRIPTION
Change the getBoards thunk to return only unarchived boards.
Create archiveBoard thunk and slice.
The previous commit message got truncated, so the archiving of a board is implemented.
Clean up the file and make the boards easier to select.
There is a not good solution and I need to find a way to fix this. Now there is a timeout of 2 seconds, so the dispatch function could get executed and the state updated to reflect the deletion. It is in `handleArchiveBoard()` function in `JobBoardTitle.tsx` file.