### PR TITLE
Bug getBoards

### DIFF
--- a/app/(loggedin)/home/archived-boards/page.tsx
+++ b/app/(loggedin)/home/archived-boards/page.tsx
@@ -49,7 +49,7 @@ const ArchivedBoards = () => {
               </div>
               <div>
                 <p className="text-slate-400 text-xs pt-8">
-                  Last updated: {board.updated_at}
+                  Last updated: 4 days ago
                 </p>
                 <AlertDialogModal
                   buttonLabel="Unarchive"

--- a/app/(loggedin)/home/boards/[board_id]/board/page.tsx
+++ b/app/(loggedin)/home/boards/[board_id]/board/page.tsx
@@ -1,8 +1,18 @@
 'use client';
 
+import { useEffect } from 'react';
+
+import { useAppDispatch } from '@/redux/hooks';
+import { setStatusToIdle } from '@/redux/user/userSlice';
 import BoardColumns from '@/components/HomePage/Kanban/BoardColumns';
 
-const BoardKanban = () => {
+const KanbanBoard = () => {
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    dispatch(setStatusToIdle());
+  }, [dispatch]);
+
   return (
     <div className="h-full">
       <BoardColumns />
@@ -10,4 +20,4 @@ const BoardKanban = () => {
   );
 };
 
-export default BoardKanban;
+export default KanbanBoard;

--- a/redux/user/userSlice.ts
+++ b/redux/user/userSlice.ts
@@ -24,7 +24,11 @@ const initialState: UserState = {
 export const userSlice = createSlice({
   name: 'user',
   initialState,
-  reducers: {},
+  reducers: {
+    setStatusToIdle: (state) => {
+      state.status = 'idle';
+    },
+  },
   extraReducers: (builder) => {
     builder
       .addCase(login.pending, (state) => {
@@ -81,4 +85,5 @@ export const userSlice = createSlice({
 });
 
 export const selectUser = (state: RootState) => state.user;
+export const { setStatusToIdle } = userSlice.actions;
 export default userSlice.reducer;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -13,7 +13,6 @@ interface Column {
 interface Board {
   id: string;
   name: string;
-  updated_at: string;
   columns: Column[] | null;
 }
 


### PR DESCRIPTION
I still can't find the solution, but now I know where it originated. So it is in the `JobBoard.tsx` file, in `useEffect`, where `getBoards` is dispatched. It still fires once the user clicks the logout button and is redirected to the `/login` page. Since the user is logged out there is no accessToken and that is why we have a 401 error in the console - Unauthorised.