### PR TITLE
Layout bug

### DIFF
--- a/components/HomePage/Kanban/ThreeDotsMenu.tsx
+++ b/components/HomePage/Kanban/ThreeDotsMenu.tsx
@@ -73,7 +73,7 @@ const ThreeDotsMenu = ({ columnOrder }: { columnOrder: number }) => {
       </div>
       <ul
         tabIndex={0}
-        className="dropdown-content menu bg-base-100 rounded-box z-[1] w-52 p-2 shadow"
+        className="dropdown-content !fixed menu bg-base-100 rounded-box z-[1] w-52 p-2 shadow"
       >
         <li>
           <div className="flex !justify-between h-12 mb-1 p-4 w-full">

--- a/components/HomePage/SideBar/JobBoard.tsx
+++ b/components/HomePage/SideBar/JobBoard.tsx
@@ -23,6 +23,8 @@ const JobBoard = () => {
           id={board.id}
           name={board.name}
           columns={[]}
+          isArchived={board.isArchived}
+          userId={board.userId}
         />
       ))}
     </div>


### PR DESCRIPTION
There was a horizontal scroll bar on the individual board screen caused by the <ul> element in the ThreeDotsMenu.tsx file.
Change the position of the element from absolute (original CSS of daisyUI to !fixed).