### PR TITLE
Fix the issue with too many getBoards requests

### DIFF
--- a/app/(loggedin)/home/boards/[board_id]/board/page.tsx
+++ b/app/(loggedin)/home/boards/[board_id]/board/page.tsx
@@ -14,7 +14,6 @@ const KanbanBoard = () => {
   useEffect(() => {
     dispatch(setStatusToIdle());
     dispatch(getBoards(accessToken as string));
-    console.log('Home/boards/boardid/board page getBoards dispatched');
   }, [dispatch, accessToken]);
 
   return (

--- a/app/(loggedin)/layout.tsx
+++ b/app/(loggedin)/layout.tsx
@@ -3,10 +3,10 @@
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 
+import { getUser } from '@/redux/user/userThunk';
 import { getBoards } from '@/redux/boards/boardsThunk';
 import Sidebar from '@/components/HomePage/SideBar/Sidebar';
 import { useAppDispatch, useAppSelector } from '@/redux/hooks';
-import { getUser } from '@/redux/user/userThunk';
 
 const HomeLayout = ({ children }: { children: React.ReactNode }) => {
   const router = useRouter();
@@ -21,9 +21,7 @@ const HomeLayout = ({ children }: { children: React.ReactNode }) => {
       router.push('/login');
     } else {
       dispatch(getBoards(accessToken));
-      console.log('Layout home page, getBoards dispatched');
       dispatch(getUser(accessToken as string));
-      console.log('accessToken, getUSer dispatched', accessToken);
     }
   }, [accessToken, router, dispatch]);
 

--- a/components/HomePage/Kanban/BoardColumns.tsx
+++ b/components/HomePage/Kanban/BoardColumns.tsx
@@ -7,7 +7,7 @@ import ThreeDotsMenu from './ThreeDotsMenu';
 import { Input } from '@/components/ui/input';
 import { returnBoardIcon } from '@/utils/ReturnIcons';
 import AlertDialogModal from '../Boards/AlertDialogModal';
-import { useAppSelector, useAppDispatch } from '@/redux/hooks';
+import { useAppDispatch, useAppSelector } from '@/redux/hooks';
 import { getBoards, updateColumnName } from '@/redux/boards/boardsThunk';
 import AddJobShortForm from '@/components/Forms/AddJobShort/AddJobShortForm';
 
@@ -30,7 +30,6 @@ const BoardColumns = () => {
       }
     } else {
       dispatch(getBoards(accessToken as string));
-      console.log('Board Columns useEffect getBoards dispatched');
     }
   }, [isEditing, currentColumnId, accessToken, dispatch]);
 
@@ -63,16 +62,6 @@ const BoardColumns = () => {
 
   const createJobApplication = () => {
     console.log('Create Job Application');
-    console.log(
-      'Company: ',
-      localStorage.getItem('company'),
-      'Job Title: ',
-      localStorage.getItem('jobTitle'),
-      'Board: ',
-      localStorage.getItem('chosenBoard'),
-      'List: ',
-      localStorage.getItem('chosenColumn')
-    );
   };
 
   return (

--- a/components/HomePage/Kanban/ThreeDotsMenu.tsx
+++ b/components/HomePage/Kanban/ThreeDotsMenu.tsx
@@ -24,8 +24,9 @@ const ThreeDotsMenu = ({ columnOrder }: { columnOrder: number }) => {
   const [isEditing, setIsEditing] = useState(false);
   const accessToken = localStorage.getItem('accessToken');
   const { boards } = useAppSelector((state) => state.boards);
-  const [selectedColumn, setSelectedColumn] = useState<number>(0);
+  const { boardsStatus } = useAppSelector((state) => state.boards);
   const currentBoard = boards.find((board) => board.id === board_id);
+  const [selectedColumn, setSelectedColumn] = useState<number>(columnOrder);
   const currentBoardColumns = currentBoard?.columns;
 
   const columnData = currentBoardColumns?.find(
@@ -36,6 +37,8 @@ const ThreeDotsMenu = ({ columnOrder }: { columnOrder: number }) => {
     const columnsArray = moveColumn(5, columnOrder, selectedColumn);
     const columns = currentBoardColumns?.map((column) => column.id);
     const columnIds = columnsArray.map((v) => columns![v]);
+
+    if (columnOrder === selectedColumn) return;
 
     dispatch(
       rearrangeColumns({
@@ -48,10 +51,11 @@ const ThreeDotsMenu = ({ columnOrder }: { columnOrder: number }) => {
   };
 
   useEffect(() => {
-    dispatch(getBoards(accessToken as string));
-    console.log('Three Dots Menu useEffect getBoards dispatched');
-    setIsEditing(false);
-  }, [dispatch, accessToken, isEditing]);
+    if (boardsStatus === 'succeeded' && isEditing) {
+      dispatch(getBoards(accessToken as string));
+      setIsEditing(false);
+    }
+  }, [dispatch, accessToken, isEditing, boardsStatus]);
 
   return (
     <div className="dropdown">

--- a/components/HomePage/SideBar/JobBoard.tsx
+++ b/components/HomePage/SideBar/JobBoard.tsx
@@ -13,7 +13,6 @@ const JobBoard = () => {
 
   useEffect(() => {
     dispatch(getBoards(accessToken as string));
-    console.log('HomePage/SideBar/Job Board useEffect getBoards dispatched');
   }, [accessToken, dispatch]);
 
   return (

--- a/components/HomePage/SideBar/UserPanel.tsx
+++ b/components/HomePage/SideBar/UserPanel.tsx
@@ -16,8 +16,6 @@ const UserPanel = () => {
   const { firstName } = useAppSelector((state) => state.user);
   const { lastName } = useAppSelector((state) => state.user);
 
-  console.log('Names: ', firstName, lastName);
-
   const userLogout = () => {
     dispatch(logout());
     router.push('/login');

--- a/redux/user/userThunk.ts
+++ b/redux/user/userThunk.ts
@@ -79,7 +79,6 @@ export const getUser = createAsyncThunk(
       });
 
       if (res.status === 200) {
-        console.log('User data from getUser thunk', res.data);
         return res.data;
       } else {
         return thunkAPI.rejectWithValue('User not found');


### PR DESCRIPTION
The 10 requests from ThreeDotsMenu.tsx component have been eliminated, by adding an if statement and firing the dispatch getBoards only if the boardsStatus is equal to "succeeded"
Clean up the files from console.logs.

Also add a condition when moving the columns if the clicked and the selected (default has been changed to clicked column's id, instead of 0) are the same no rearrange request is fired.

The reload of the page also results in a lesser number of requests:
36 requests
21.4 MB transferred
112 MB resources
Finish: 9.86 s
DOMContentLoaded: 1.55 s
Load: 8.52 s