### PR TITLE
Add job extended

### DIFF
--- a/components/HomePage/Kanban/BoardColumns.tsx
+++ b/components/HomePage/Kanban/BoardColumns.tsx
@@ -124,7 +124,12 @@ const BoardColumns = () => {
             >
               <AddJobShortForm columnOrder={column.order} />
             </AlertDialogModal>
-            <JobPostCard />
+            <JobPostCard
+              title="Frontend Developer"
+              companyName="Amazon"
+              status="Job Moved"
+              timeStamp="August 30th 2024, 10:44 am"
+            />
           </section>
         ))}
     </div>

--- a/components/HomePage/Kanban/BoardColumns.tsx
+++ b/components/HomePage/Kanban/BoardColumns.tsx
@@ -5,6 +5,7 @@ import { ChangeEvent, useEffect, useState } from 'react';
 
 import ThreeDotsMenu from './ThreeDotsMenu';
 import { Input } from '@/components/ui/input';
+import JobPostCard from './JobPosts/JobPostCard';
 import { returnBoardIcon } from '@/utils/ReturnIcons';
 import { createJobPost } from '@/redux/jobs/jobsThunk';
 import AlertDialogModal from '../Boards/AlertDialogModal';
@@ -119,10 +120,11 @@ const BoardColumns = () => {
               buttonCancel="Discard"
               buttonConfirm="Save Job"
               actionFunction={createJobApplication}
-              stylings="w-11/12 flex justify-center text-2xl border py-3 mx-auto rounded-md hover:border-blue-500 transition duration-300 delay-150 cursor-pointer"
+              stylings="w-11/12 flex justify-center text-2xl border py-3 mb-4 mx-auto rounded-md hover:border-blue-500 transition duration-300 delay-150 cursor-pointer"
             >
               <AddJobShortForm columnOrder={column.order} />
             </AlertDialogModal>
+            <JobPostCard />
           </section>
         ))}
     </div>

--- a/components/HomePage/Kanban/JobPosts/JobPostCard.tsx
+++ b/components/HomePage/Kanban/JobPosts/JobPostCard.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+const JobPostCard = () => {
+  return <div>JobPostCard</div>;
+};
+
+export default JobPostCard;

--- a/components/HomePage/Kanban/JobPosts/JobPostCard.tsx
+++ b/components/HomePage/Kanban/JobPosts/JobPostCard.tsx
@@ -1,15 +1,13 @@
 'use client';
 
 import { useState } from 'react';
-import { FiPlusCircle } from 'react-icons/fi';
 import { LiaLinkSolid } from 'react-icons/lia';
 import { RiDeleteBinLine } from 'react-icons/ri';
 
+import { returnJobPostIcon } from '@/utils/ReturnIcons';
 import {
   Card,
-  CardContent,
   CardDescription,
-  CardFooter,
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
@@ -20,7 +18,12 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 
-const JobPostCard = () => {
+const JobPostCard = ({
+  title,
+  companyName,
+  status,
+  timeStamp,
+}: JobPostCardProps) => {
   const [showIcons, setShowIcons] = useState(false);
 
   const toggleIcons = () => {
@@ -37,8 +40,10 @@ const JobPostCard = () => {
     >
       <div className="flex h-[90px]">
         <CardHeader className="w-3/4">
-          <CardTitle className="!p-0 !m-0">Front end Developer</CardTitle>
-          <CardDescription className="text-white">Amazon</CardDescription>
+          <CardTitle className="!p-0 !m-0">{title}</CardTitle>
+          <CardDescription className="text-white">
+            {companyName}
+          </CardDescription>
         </CardHeader>
         <div className="flex flex-col gap-1 py-1 pr-2 items-end w-1/4 mt-1">
           {showIcons ? (
@@ -61,14 +66,28 @@ const JobPostCard = () => {
                 </TooltipTrigger>
                 <TooltipContent>
                   <p>
-                    <span>Job Created</span>
+                    <span>{status}</span>
                     <span> | </span>
-                    <span>August 30th 2024, 10:44 am</span>
+                    <span>{timeStamp}</span>
                   </p>
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>
-            <FiPlusCircle className="h-[24px] w-[24px] rounded-md p-[1px]" />
+            {returnJobPostIcon(
+              status === 'Job Created'
+                ? 'HiOutlinePlusCircle'
+                : status === 'Deadline'
+                ? 'HiOutlineClock'
+                : status === 'Applied'
+                ? 'HiOutlineFolder'
+                : status === 'Interview'
+                ? 'PiBriefcaseLight'
+                : status === 'Offer Received'
+                ? 'GoTrophy'
+                : status === 'Job Moved'
+                ? 'GoInbox'
+                : 'HiOutlinePlusCircle'
+            )}
           </div>
         </div>
       </div>

--- a/components/HomePage/Kanban/JobPosts/JobPostCard.tsx
+++ b/components/HomePage/Kanban/JobPosts/JobPostCard.tsx
@@ -1,7 +1,79 @@
 'use client';
 
+import { useState } from 'react';
+import { FiPlusCircle } from 'react-icons/fi';
+import { LiaLinkSolid } from 'react-icons/lia';
+import { RiDeleteBinLine } from 'react-icons/ri';
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+
 const JobPostCard = () => {
-  return <div>JobPostCard</div>;
+  const [showIcons, setShowIcons] = useState(false);
+
+  const toggleIcons = () => {
+    setTimeout(() => {
+      setShowIcons((prev) => !prev);
+    }, 200);
+  };
+
+  return (
+    <Card
+      onMouseEnter={toggleIcons}
+      onMouseLeave={toggleIcons}
+      className="w-11/12 mx-auto mt-2 rounded-sm bg-violet-500 text-white"
+    >
+      <div className="flex h-[90px]">
+        <CardHeader className="w-3/4">
+          <CardTitle className="!p-0 !m-0">Front end Developer</CardTitle>
+          <CardDescription className="text-white">Amazon</CardDescription>
+        </CardHeader>
+        <div className="flex flex-col gap-1 py-1 pr-2 items-end w-1/4 mt-1">
+          {showIcons ? (
+            <div className="h-[24px] w-[24px] rounded-md cursor-pointer border hover:border-gray-400">
+              <RiDeleteBinLine className="h-5 w-5 m-auto" />
+            </div>
+          ) : (
+            <div className="h-[24px] w-[24px] rounded-md p-[1px]"></div>
+          )}
+          {showIcons ? (
+            <LiaLinkSolid className="h-[24px] w-[24px] border rounded-md p-[1px] cursor-pointer hover:border-gray-400" />
+          ) : (
+            <div className="h-[24px] w-[24px] rounded-md p-[1px]"></div>
+          )}
+          <div className="flex justify-center items-center gap-2">
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="text-xs text-white cursor-help">35 d</span>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>
+                    <span>Job Created</span>
+                    <span> | </span>
+                    <span>August 30th 2024, 10:44 am</span>
+                  </p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+            <FiPlusCircle className="h-[24px] w-[24px] rounded-md p-[1px]" />
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
 };
 
 export default JobPostCard;

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,0 +1,76 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-xl border bg-card text-card-foreground shadow",
+      className
+    )}
+    {...props}
+  />
+))
+Card.displayName = "Card"
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+))
+CardHeader.displayName = "CardHeader"
+
+const CardTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3
+    ref={ref}
+    className={cn("font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+))
+CardTitle.displayName = "CardTitle"
+
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+CardDescription.displayName = "CardDescription"
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+))
+CardContent.displayName = "CardContent"
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+))
+CardFooter.displayName = "CardFooter"
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,6 +1,6 @@
-import * as React from "react"
+import * as React from 'react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 const Card = React.forwardRef<
   HTMLDivElement,
@@ -9,13 +9,13 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-xl border bg-card text-card-foreground shadow",
+      'rounded-xl border bg-card text-card-foreground shadow',
       className
     )}
     {...props}
   />
-))
-Card.displayName = "Card"
+));
+Card.displayName = 'Card';
 
 const CardHeader = React.forwardRef<
   HTMLDivElement,
@@ -23,11 +23,11 @@ const CardHeader = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    className={cn('flex flex-col space-y-1.5 p-2', className)}
     {...props}
   />
-))
-CardHeader.displayName = "CardHeader"
+));
+CardHeader.displayName = 'CardHeader';
 
 const CardTitle = React.forwardRef<
   HTMLParagraphElement,
@@ -35,11 +35,11 @@ const CardTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <h3
     ref={ref}
-    className={cn("font-semibold leading-none tracking-tight", className)}
+    className={cn('font-semibold leading-none tracking-tight', className)}
     {...props}
   />
-))
-CardTitle.displayName = "CardTitle"
+));
+CardTitle.displayName = 'CardTitle';
 
 const CardDescription = React.forwardRef<
   HTMLParagraphElement,
@@ -47,19 +47,19 @@ const CardDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <p
     ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
+    className={cn('text-sm text-muted-foreground', className)}
     {...props}
   />
-))
-CardDescription.displayName = "CardDescription"
+));
+CardDescription.displayName = 'CardDescription';
 
 const CardContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
-))
-CardContent.displayName = "CardContent"
+  <div ref={ref} className={cn('p-6 pt-0', className)} {...props} />
+));
+CardContent.displayName = 'CardContent';
 
 const CardFooter = React.forwardRef<
   HTMLDivElement,
@@ -67,10 +67,17 @@ const CardFooter = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("flex items-center p-6 pt-0", className)}
+    className={cn('flex items-center p-6 pt-0', className)}
     {...props}
   />
-))
-CardFooter.displayName = "CardFooter"
+));
+CardFooter.displayName = 'CardFooter';
 
-export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardDescription,
+  CardContent,
+};

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -19,7 +19,7 @@ const TooltipContent = React.forwardRef<
     ref={ref}
     sideOffset={sideOffset}
     className={cn(
-      'max-w-[180px] z-50 overflow-hidden rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+      'max-w-[280px] z-50 overflow-hidden rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
       className
     )}
     {...props}

--- a/data/job-status-items.ts
+++ b/data/job-status-items.ts
@@ -1,0 +1,28 @@
+const jobPostItems = [
+  {
+    jobStatus: 'Job Created',
+    icon: 'HiOutlinePlusCircle',
+  },
+  {
+    jobStatus: 'Deadline',
+    icon: 'HiOutlineClock',
+  },
+  {
+    jobStatus: 'Applied',
+    icon: 'HiOutlineFolder',
+  },
+  {
+    jobStatus: 'Interview',
+    icon: 'PiBriefcaseLight',
+  },
+  {
+    jobStatus: 'Offer Received',
+    icon: 'GoTrophy',
+  },
+  {
+    jobStatus: 'Job Moved',
+    icon: 'GoInbox',
+  },
+];
+
+export default jobPostItems;

--- a/enums/index.ts
+++ b/enums/index.ts
@@ -5,9 +5,18 @@ export enum BoardIcons {
   GoTrophy = 4,
   HiOutlineThumbDown = 5,
 }
-  
+
 export enum MenuIcons {
-  RiContactsLine = 'RiContactsLine',
   RiFolder2Line = 'RiFolder2Line',
+  RiContactsLine = 'RiContactsLine',
   PiBriefcaseLight = 'PiBriefcaseLight',
+}
+
+export enum JobPostIcons {
+  GoInbox = 'GoInbox',
+  GoTrophy = 'GoTrophy',
+  HiOutlineClock = 'HiOutlineClock',
+  HiOutlineFolder = 'HiOutlineFolder',
+  PiBriefcaseLight = 'PiBriefcaseLight',
+  HiOutlinePlusCircle = 'HiOutlinePlusCircle',
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -40,6 +40,13 @@ interface JobPostShort {
   columnId: string;
 }
 
+interface JobPostCardProps {
+  title: string;
+  companyName: string;
+  status: string;
+  timeStamp: string;
+}
+
 interface WorkDocument {
   id: string;
   userId: string;

--- a/utils/ReturnIcons.tsx
+++ b/utils/ReturnIcons.tsx
@@ -44,17 +44,17 @@ export const returnMenuIcon = (icon: string) => {
 export const returnJobPostIcon = (icon: string) => {
   switch (icon) {
     case JobPostIcons.PiBriefcaseLight:
-      return <PiBriefcaseLight />;
+      return <PiBriefcaseLight className="h-6 w-6" />;
     case JobPostIcons.HiOutlinePlusCircle:
-      return <HiOutlinePlusCircle />;
+      return <HiOutlinePlusCircle className="h-6 w-6" />;
     case JobPostIcons.HiOutlineClock:
-      return <HiOutlineClock />;
+      return <HiOutlineClock className="h-6 w-6" />;
     case JobPostIcons.HiOutlineFolder:
-      return <HiOutlineFolder />;
+      return <HiOutlineFolder className="h-6 w-6" />;
     case JobPostIcons.GoInbox:
-      return <GoInbox />;
+      return <GoInbox className="h-6 w-6" />;
     case JobPostIcons.GoTrophy:
-      return <GoTrophy />;
+      return <GoTrophy className="h-6 w-6" />;
     default:
       return null;
   }

--- a/utils/ReturnIcons.tsx
+++ b/utils/ReturnIcons.tsx
@@ -1,10 +1,15 @@
-import { GoTrophy } from 'react-icons/go';
 import { SlBriefcase } from 'react-icons/sl';
 import { PiBriefcaseLight } from 'react-icons/pi';
-import { HiOutlineThumbDown } from 'react-icons/hi';
+import { GoTrophy, GoInbox } from 'react-icons/go';
+import { BoardIcons, MenuIcons, JobPostIcons } from '@/enums';
 import { SlEnvolopeLetter, SlMagicWand } from 'react-icons/sl';
 import { RiContactsLine, RiFolder2Line } from 'react-icons/ri';
-import { BoardIcons, MenuIcons } from '@/enums';
+import {
+  HiOutlineThumbDown,
+  HiOutlinePlusCircle,
+  HiOutlineClock,
+  HiOutlineFolder,
+} from 'react-icons/hi';
 
 export const returnBoardIcon = (id: number) => {
   switch (id) {
@@ -31,6 +36,25 @@ export const returnMenuIcon = (icon: string) => {
       return <RiFolder2Line />;
     case MenuIcons.PiBriefcaseLight:
       return <PiBriefcaseLight />;
+    default:
+      return null;
+  }
+};
+
+export const returnJobPostIcon = (icon: string) => {
+  switch (icon) {
+    case JobPostIcons.PiBriefcaseLight:
+      return <PiBriefcaseLight />;
+    case JobPostIcons.HiOutlinePlusCircle:
+      return <HiOutlinePlusCircle />;
+    case JobPostIcons.HiOutlineClock:
+      return <HiOutlineClock />;
+    case JobPostIcons.HiOutlineFolder:
+      return <HiOutlineFolder />;
+    case JobPostIcons.GoInbox:
+      return <GoInbox />;
+    case JobPostIcons.GoTrophy:
+      return <GoTrophy />;
     default:
       return null;
   }


### PR DESCRIPTION
Add a Card component from shadcn/ui
Create a job post card. Modify the enums and ReturnIcons files to handle icons for job post status.
Render the job post card with props.