### PR TITLE
Combo box problem 1

### DIFF
--- a/components/Forms/AddJobShort/AddJobShortForm.tsx
+++ b/components/Forms/AddJobShort/AddJobShortForm.tsx
@@ -33,8 +33,7 @@ const AddJobShortForm = ({ columnOrder }: { columnOrder: number }) => {
   const initialBoardName = boards.find((board) => board.id === board_id)!.name;
 
   const chosenBoard = localStorage.getItem('chosenBoard') || initialBoardName;
-  const chosenColumn =
-    localStorage.getItem('chosenColumn') || initialColumnName;
+  const chosenColumn = localStorage.getItem('chosenColumn');
 
   const [firstColumnOfTheBoard, setFirstColumnOfTheBoard] =
     useState(initialColumnName);
@@ -80,16 +79,6 @@ const AddJobShortForm = ({ columnOrder }: { columnOrder: number }) => {
     setJobTitle(e.target.value);
     localStorage.setItem('jobTitle', e.target.value);
   };
-
-  useEffect(() => {
-    if (initialColumnName) {
-      const columnId = boardColumns!.find(
-        (column) => column.name === initialColumnName
-      )?.id;
-      localStorage.setItem('columnId', columnId as string);
-      localStorage.setItem('chosenColumn', initialColumnName);
-    }
-  }, [initialColumnName, boardColumns]);
 
   console.log('initialColumnName: ', initialColumnName);
   console.log('initialBoardName: ', initialBoardName);
@@ -163,7 +152,8 @@ const AddJobShortForm = ({ columnOrder }: { columnOrder: number }) => {
                   itemsType="boards"
                   searchItem="Boards"
                   initialBoardString={initialBoardName}
-                  initialColumnString={firstColumnOfTheBoard}
+                  // initialColumnString={initialColumnName}
+                  firstColumnOfTheBoard={firstColumnOfTheBoard}
                   sendDataToParent={handleDataFromChild}
                 />
                 <FormMessage />
@@ -187,8 +177,9 @@ const AddJobShortForm = ({ columnOrder }: { columnOrder: number }) => {
                   itemsType="columns"
                   items={boardColumns}
                   initialColumnString={initialColumnName}
+                  firstColumnOfTheBoard={firstColumnOfTheBoard}
+                  sendDataToParent={handleDataFromChild}
                   // initialBoardString={initialBoardName}
-                  // sendDataToParent={handleDataFromChild}
                 />
                 <FormMessage />
               </FormItem>

--- a/components/Forms/AddJobShort/AddJobShortForm.tsx
+++ b/components/Forms/AddJobShort/AddJobShortForm.tsx
@@ -47,7 +47,7 @@ const AddJobShortForm = ({ columnOrder }: { columnOrder: number }) => {
       setFirstColumnOfTheBoard(changedBoard.columns[0].name);
     }
 
-    console.log('firstColumnOfTheBoard: ', firstColumnOfTheBoard);
+    // console.log('firstColumnOfTheBoard: ', firstColumnOfTheBoard);
     localStorage.setItem('firstColumnOfTheBoard', firstColumnOfTheBoard);
     const values = {
       accessToken,
@@ -80,8 +80,8 @@ const AddJobShortForm = ({ columnOrder }: { columnOrder: number }) => {
     localStorage.setItem('jobTitle', e.target.value);
   };
 
-  console.log('initialColumnName: ', initialColumnName);
-  console.log('initialBoardName: ', initialBoardName);
+  // console.log('initialColumnName: ', initialColumnName);
+  // console.log('initialBoardName: ', initialBoardName);
   // console.log('chosenBoard: ', chosenBoard);
   // console.log('chosenColumn: ', chosenColumn);
 

--- a/components/Forms/AddJobShort/ComboBoardListBox.tsx
+++ b/components/Forms/AddJobShort/ComboBoardListBox.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { use, useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
 import { CaretSortIcon, CheckIcon } from '@radix-ui/react-icons';
 
@@ -28,6 +28,7 @@ const ComboBoardListBox = ({
   searchItem,
   initialBoardString,
   initialColumnString,
+  firstColumnOfTheBoard,
   sendDataToParent,
 }: ComboBoardListBoxProps) => {
   const { board_id } = useParams();
@@ -51,8 +52,9 @@ const ComboBoardListBox = ({
   console.log('ValueBoard: ', valueBoard);
   console.log('ValueColumn: ', valueColumn);
 
-  const firstColumn =
-    localStorage.getItem('firstColumnOfTheBoard') || initialColumnString;
+  const firstColumn = localStorage.getItem('firstColumnOfTheBoard');
+
+  console.log('firstColumn: ', firstColumn);
 
   useEffect(() => {
     if (itemsType === 'boards') {
@@ -67,10 +69,18 @@ const ComboBoardListBox = ({
       const columnId = items.find((item) => item.name === chosenColumn)?.id;
       localStorage.setItem('columnId', columnId as string);
     }
-  }, [valueBoard, chosenBoard, chosenColumn, itemsType]);
+  }, [valueBoard, chosenBoard, chosenColumn, itemsType, firstColumnOfTheBoard]);
 
   console.log('chosenBoard: ', chosenBoard);
   console.log('chosenColumn: ', chosenColumn);
+
+  useEffect(() => {
+    if (boardValueChanged) {
+      if (chosenColumn === firstColumnOfTheBoard) {
+        localStorage.setItem('chosenColumn', firstColumnOfTheBoard!);
+      }
+    }
+  }, [boardValueChanged, chosenColumn, firstColumnOfTheBoard]);
 
   const handleBoardChange = () => {
     sendDataToParent(chosenBoard!);
@@ -114,7 +124,7 @@ const ComboBoardListBox = ({
                     onSelect={() => {
                       itemsType === 'boards'
                         ? (setChosenBoard(item.name),
-                          setChosenColumn(firstColumn),
+                          setChosenColumn(firstColumn!),
                           setValueBoard(item.name),
                           setBoardValueChanged(true),
                           { handleBoardChange })

--- a/components/Forms/AddJobShort/ComboBoardListBox.tsx
+++ b/components/Forms/AddJobShort/ComboBoardListBox.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { use, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
 import { CaretSortIcon, CheckIcon } from '@radix-ui/react-icons';
 
@@ -49,12 +49,12 @@ const ComboBoardListBox = ({
   const [valueBoard, setValueBoard] = useState(initialBoardString);
   const [valueColumn, setValueColumn] = useState(initialColumnString);
 
-  console.log('ValueBoard: ', valueBoard);
-  console.log('ValueColumn: ', valueColumn);
+  // console.log('ValueBoard: ', valueBoard);
+  // console.log('ValueColumn: ', valueColumn);
 
   const firstColumn = localStorage.getItem('firstColumnOfTheBoard');
 
-  console.log('firstColumn: ', firstColumn);
+  // console.log('firstColumn: ', firstColumn);
 
   useEffect(() => {
     if (itemsType === 'boards') {
@@ -71,8 +71,8 @@ const ComboBoardListBox = ({
     }
   }, [valueBoard, chosenBoard, chosenColumn, itemsType, firstColumnOfTheBoard]);
 
-  console.log('chosenBoard: ', chosenBoard);
-  console.log('chosenColumn: ', chosenColumn);
+  // console.log('chosenBoard: ', chosenBoard);
+  // console.log('chosenColumn: ', chosenColumn);
 
   useEffect(() => {
     if (boardValueChanged) {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -92,7 +92,8 @@ interface ComboBoardListBoxProps {
   initialBoardString?: string;
   initialColumnString?: string;
   itemsType?: 'boards' | 'columns';
-  sendDataToParent?: (value: string) => void;
+  firstColumnOfTheBoard?: string;
+  sendDataToParent: (value: string) => void;
 }
 
 interface AlertDialogProps {


### PR DESCRIPTION
So, the problem is that when the user clicks on the "+" to create a new job. Here he has two choices to select - boards and columns. The AddJob modal loads by default the current Job board and the column, from which the "+" sign was clicked on. If the user starts by changing the boards first, the initial column selected remains the same, which is a fault. The column should reset to the first (columnOrder of 0) column of the newly selected board from the drop-down boards menu. This should be the default behavior when selecting a new board.
If the user starts changing the columns first then whatever column he chooses, this column should become the current one and shown in the drop-down menu. When the column got changed and then the user goes to change the board the default behavior for changing the board should expected - the first column of the newly selected board should show in the column's drop-down menu.
This behavior should repeated steadily regardless of how many and in what order columns or boards are changed.