### PR TITLE
Button create job fix

### DIFF
--- a/components/HomePage/Boards/AlertDialogModal.tsx
+++ b/components/HomePage/Boards/AlertDialogModal.tsx
@@ -14,11 +14,13 @@ import {
 } from '@/components/ui/alert-dialog';
 
 const AlertDialogModal = ({
+  open,
   children,
   stylings,
   dialogText,
   dialogTitle,
   buttonLabel,
+  onOpenChange,
   buttonCancel,
   buttonVariant,
   buttonConfirm,
@@ -32,7 +34,7 @@ const AlertDialogModal = ({
   };
 
   return (
-    <AlertDialog>
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
       <AlertDialogTrigger asChild>
         <Button variant={buttonVariant} className={cn(stylings)}>
           {buttonLabel}

--- a/components/HomePage/HomeNavbar/CreateMenu.tsx
+++ b/components/HomePage/HomeNavbar/CreateMenu.tsx
@@ -62,7 +62,10 @@ const CreateMenu = () => {
                 <li>
                   <div
                     className="flex items-center px-4 mt-1 pb-1 cursor-pointer hover:bg-blue-400 rounded-md text-white"
-                    onClick={() => setShowJobModal(true)}
+                    onClick={() => {
+                      setShowJobModal(true);
+                      clearDropDown();
+                    }}
                   >
                     <PiBriefcaseLight />
                     <span className="ml-2 text-base">Job</span>
@@ -92,7 +95,10 @@ const CreateMenu = () => {
           isFormValid={isFormValid}
           actionFunction={createJobApplication}
           open={showJobModal} // Add this prop
-          onOpenChange={setShowJobModal} // Add this prop
+          onOpenChange={(open) => {
+            setShowJobModal(open);
+            if (!open) clearDropDown();
+          }}
         >
           <AddJobShortForm
             columnOrder={0}

--- a/components/HomePage/HomeNavbar/CreateMenu.tsx
+++ b/components/HomePage/HomeNavbar/CreateMenu.tsx
@@ -19,6 +19,7 @@ const CreateMenu = () => {
   const dispatch = useAppDispatch();
   const [isFormValid, setIsFormValid] = useState(false);
   const accessToken = localStorage.getItem('accessToken');
+  const [showJobModal, setShowJobModal] = useState(false);
   const clearDropDown = () => {
     const element = document.querySelector('#close-dropdown')!.children[0]
       .children[0].children[0].children[0].children[0] as HTMLElement;
@@ -59,27 +60,12 @@ const CreateMenu = () => {
             <NavigationMenuContent className="bg-blue-500 p-2">
               <ul>
                 <li>
-                  <div className="flex items-center px-4 mt-1 pb-1 cursor-pointer hover:bg-blue-400 rounded-md text-white">
-                    <AlertDialogModal
-                      buttonLabel={
-                        <>
-                          <PiBriefcaseLight />
-                          <span className="ml-2 text-base">Job</span>
-                        </>
-                      }
-                      buttonVariant="none"
-                      dialogTitle="Add Job"
-                      buttonCancel="Discard"
-                      buttonConfirm="Save Job"
-                      isFormValid={isFormValid}
-                      actionFunction={createJobApplication}
-                      stylings="m-0 pl-0 pr-8 !items-left rounded-md hover:bg-blue-400 cursor-pointer inline-flex w-full"
-                    >
-                      <AddJobShortForm
-                        columnOrder={0}
-                        onValidationChange={setIsFormValid}
-                      />
-                    </AlertDialogModal>
+                  <div
+                    className="flex items-center px-4 mt-1 pb-1 cursor-pointer hover:bg-blue-400 rounded-md text-white"
+                    onClick={() => setShowJobModal(true)}
+                  >
+                    <PiBriefcaseLight />
+                    <span className="ml-2 text-base">Job</span>
                   </div>
                 </li>
                 <li>
@@ -95,6 +81,25 @@ const CreateMenu = () => {
           </NavigationMenuItem>
         </NavigationMenuList>
       </NavigationMenu>
+
+      {showJobModal && (
+        <AlertDialogModal
+          buttonLabel="" // Remove the buttonLabel since we don't need a trigger button
+          buttonVariant="none"
+          dialogTitle="Add Job"
+          buttonCancel="Discard"
+          buttonConfirm="Save Job"
+          isFormValid={isFormValid}
+          actionFunction={createJobApplication}
+          open={showJobModal} // Add this prop
+          onOpenChange={setShowJobModal} // Add this prop
+        >
+          <AddJobShortForm
+            columnOrder={0}
+            onValidationChange={setIsFormValid}
+          />
+        </AlertDialogModal>
+      )}
     </div>
   );
 };

--- a/components/HomePage/HomeNavbar/CreateMenu.tsx
+++ b/components/HomePage/HomeNavbar/CreateMenu.tsx
@@ -17,20 +17,15 @@ import {
 
 const CreateMenu = () => {
   const dispatch = useAppDispatch();
+  const [, setIsMenuOpen] = useState(false);
   const [isFormValid, setIsFormValid] = useState(false);
   const accessToken = localStorage.getItem('accessToken');
   const [showJobModal, setShowJobModal] = useState(false);
-  const clearDropDown = () => {
-    const element = document.querySelector('#close-dropdown')!.children[0]
-      .children[0].children[0].children[0].children[0] as HTMLElement;
-
-    element.click();
-  };
 
   const createJobApplication = () => {
     if (!isFormValid) return;
 
-    clearDropDown();
+    setShowJobModal(false);
 
     const jobPost = {
       jobPostStatus: 'Job Created',
@@ -44,7 +39,7 @@ const CreateMenu = () => {
   };
 
   const createContact = () => {
-    clearDropDown();
+    setShowJobModal(false);
 
     // TODO: Implement contact creation
   };
@@ -64,7 +59,7 @@ const CreateMenu = () => {
                     className="flex items-center px-4 mt-1 pb-1 cursor-pointer hover:bg-blue-400 rounded-md text-white"
                     onClick={() => {
                       setShowJobModal(true);
-                      clearDropDown();
+                      setIsFormValid(false);
                     }}
                   >
                     <PiBriefcaseLight />
@@ -88,16 +83,16 @@ const CreateMenu = () => {
       {showJobModal && (
         <AlertDialogModal
           buttonLabel="" // Remove the buttonLabel since we don't need a trigger button
+          open={showJobModal}
           buttonVariant="none"
           dialogTitle="Add Job"
           buttonCancel="Discard"
           buttonConfirm="Save Job"
           isFormValid={isFormValid}
           actionFunction={createJobApplication}
-          open={showJobModal} // Add this prop
           onOpenChange={(open) => {
             setShowJobModal(open);
-            if (!open) clearDropDown();
+            if (!open) setIsMenuOpen(false);
           }}
         >
           <AddJobShortForm

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -96,7 +96,6 @@ interface ComboBoardListBoxProps {
 }
 
 interface AlertDialogProps {
-  buttonLabel?: React.ReactNode;
   buttonVariant?:
     | null
     | 'link'
@@ -109,6 +108,7 @@ interface AlertDialogProps {
     | 'outlineNew'
     | 'destructive'
     | undefined;
+  open: boolean;
   stylings?: string;
   dialogTitle: string;
   dialogText?: string;
@@ -117,6 +117,8 @@ interface AlertDialogProps {
   isFormValid?: boolean;
   children?: React.ReactNode;
   actionFunction?: () => void;
+  buttonLabel?: React.ReactNode;
+  onOpenChange: (open: boolean) => void;
 }
 
 interface InputElementProps {


### PR DESCRIPTION
The problem of modal disappearing when the user moves the cursor out of the app browser's screen (when the user is using two or more screens with extended display functionalities) or when the user clicks on the field and selects a remembered value for company or job title is fixed. Also, a minor glitch is fixed that shows the drop-down menu after the user clicks on the Save Job or Discard button. Finally, refactoring is done on the clearDropDown function and replaced with useState.