### PR TITLE
Job post contacts

### DIFF
--- a/components/Forms/AddContact/CompaniesInput.tsx
+++ b/components/Forms/AddContact/CompaniesInput.tsx
@@ -18,12 +18,20 @@ const CompaniesInput = ({ companies, setCompanies }: CompaniesInputProps) => {
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter' && inputValue.trim() !== '') {
       setCompanies([...companies, inputValue.trim()]);
+      localStorage.setItem(
+        'companies',
+        JSON.stringify([...companies, inputValue.trim()])
+      );
       setInputValue('');
     }
   };
 
   const handleRemoveCompany = (company: string) => {
     setCompanies(companies.filter((c) => c !== company));
+    localStorage.setItem(
+      'companies',
+      JSON.stringify(companies.filter((c) => c !== company))
+    );
   };
 
   return (

--- a/components/Forms/AddContact/ContactSideBar.tsx
+++ b/components/Forms/AddContact/ContactSideBar.tsx
@@ -24,6 +24,10 @@ const ContactSideBar = ({ jobs, user, job_id }: ContactSideBarProps) => {
     const currentJob = jobs.jobPosts.find((job) => job.id === job_id);
     if (currentJob) {
       setJobsConnectedToContact([currentJob]);
+      localStorage.setItem(
+        'jobsConnectedToContact',
+        JSON.stringify([currentJob])
+      );
     }
   }, [job_id, jobs.jobPosts]);
 
@@ -36,12 +40,20 @@ const ContactSideBar = ({ jobs, user, job_id }: ContactSideBarProps) => {
       !jobsConnectedToContact.some((job) => job.id === jobToAdd.id)
     ) {
       setJobsConnectedToContact([...jobsConnectedToContact, jobToAdd]);
+      localStorage.setItem(
+        'jobsConnectedToContact',
+        JSON.stringify([...jobsConnectedToContact, jobToAdd])
+      );
     }
   };
 
   const handleUnlinkJob = (jobId: string) => {
     setJobsConnectedToContact((prevJobs) =>
       prevJobs.filter((job) => job.id !== jobId)
+    );
+    localStorage.setItem(
+      'jobsConnectedToContact',
+      JSON.stringify(jobsConnectedToContact.filter((job) => job.id !== jobId))
     );
   };
 

--- a/components/Forms/AddContact/CreateContactForm.tsx
+++ b/components/Forms/AddContact/CreateContactForm.tsx
@@ -35,19 +35,19 @@ const CreateContactForm = ({
   const [comment, setComment] = useState('');
   const [boardId, setBoardId] = useState('');
   const [lastName, setLastName] = useState('');
-  const [companyLocation, setCompanyLocation] = useState('');
   const [photoUrl, setPhotoUrl] = useState('');
   const [jobTitle, setJobTitle] = useState('');
   const [firstName, setFirstName] = useState('');
+  const [gitHubUrl, setGitHubUrl] = useState('');
+  const [twitterUrl, setTwitterUrl] = useState('');
   const { job_id } = useParams<{ job_id: string }>();
   const user = useAppSelector((state) => state.user);
   const jobs = useAppSelector((state) => state.jobs);
-  const [twitterUrl, setTwitterUrl] = useState('');
-  const [gitHubUrl, setGitHubUrl] = useState('');
+  const [facebookUrl, setFacebookUrl] = useState('');
+  const [linkedinUrl, setLinkedinUrl] = useState('');
   const accessToken = localStorage.getItem('accessToken');
   const [companies, setCompanies] = useState<string[]>([]);
-  const [linkedinUrl, setLinkedinUrl] = useState('');
-  const [facebookUrl, setFacebookUrl] = useState('');
+  const [companyLocation, setCompanyLocation] = useState('');
   const selectedJob = jobs.jobPosts.find((job) => job.id === job_id);
   const [emails, setEmails] = useState<{ id: string; value: string }[]>([]);
   const [phones, setPhones] = useState<{ id: string; value: string }[]>([]);
@@ -91,6 +91,7 @@ const CreateContactForm = ({
   useEffect(() => {
     if (selectedCompanyName) {
       setCompanies([selectedCompanyName]);
+      localStorage.setItem('companies', JSON.stringify([selectedCompanyName]));
     }
   }, [selectedCompanyName]);
 
@@ -108,6 +109,7 @@ const CreateContactForm = ({
       const reader = new FileReader();
       reader.onload = () => {
         setPhotoUrl(reader.result as string);
+        // TODO: Implement image upload to the server and save the URL to the local storage
       };
       reader.readAsDataURL(file);
     }
@@ -116,8 +118,16 @@ const CreateContactForm = ({
   const handleRemoveContactType = (type: 'email' | 'phone', id: string) => {
     if (type === 'email') {
       setEmails(emails.filter((email) => email.id !== id));
+      localStorage.setItem(
+        'emails',
+        JSON.stringify(emails.filter((email) => email.id !== id))
+      );
     } else if (type === 'phone') {
       setPhones(phones.filter((phone) => phone.id !== id));
+      localStorage.setItem(
+        'phones',
+        JSON.stringify(phones.filter((phone) => phone.id !== id))
+      );
     }
   };
 
@@ -129,29 +139,37 @@ const CreateContactForm = ({
     switch (fieldName) {
       case 'twitterUrl':
         setTwitterUrl(value);
+        localStorage.setItem('twitterUrl', value);
         break;
       case 'gitHubUrl':
         setGitHubUrl(value);
+        localStorage.setItem('gitHubUrl', value);
         break;
       case 'linkedinUrl':
         setLinkedinUrl(value);
+        localStorage.setItem('linkedinUrl', value);
         break;
       case 'facebookUrl':
         setFacebookUrl(value);
+        localStorage.setItem('facebookUrl', value);
         break;
       case 'lastName':
         setLastName(value);
         form.setValue('lastName', value);
+        localStorage.setItem('lastName', value);
         break;
       case 'firstName':
         setFirstName(value);
         form.setValue('firstName', value);
+        localStorage.setItem('firstName', value);
         break;
       case 'companyLocation':
         setCompanyLocation(value);
+        localStorage.setItem('companyLocation', value);
         break;
       case 'jobTitle':
         setJobTitle(value);
+        localStorage.setItem('jobTitle', value);
         break;
       default:
         break;
@@ -160,22 +178,30 @@ const CreateContactForm = ({
 
   const handleAddEmail = () => {
     setEmails([...emails, { id: uuidv4(), value: '' }]);
+    localStorage.setItem('emails', JSON.stringify(emails));
   };
 
   const handleAddPhone = () => {
     setPhones([...phones, { id: uuidv4(), value: '' }]);
+    localStorage.setItem('phones', JSON.stringify(phones));
   };
 
-  const handleEmailChange = (id: string, value: string) => {
+  const handleEmailChange = (id: string, value: string, type: string) => {
     setEmails((prevEmails) =>
-      prevEmails.map((email) => (email.id === id ? { ...email, value } : email))
+      prevEmails.map((email) =>
+        email.id === id ? { ...email, value, type } : email
+      )
     );
+    localStorage.setItem('emails', JSON.stringify(emails));
   };
 
-  const handlePhoneChange = (id: string, value: string) => {
+  const handlePhoneChange = (id: string, value: string, type: string) => {
     setPhones((prevPhones) =>
-      prevPhones.map((phone) => (phone.id === id ? { ...phone, value } : phone))
+      prevPhones.map((phone) =>
+        phone.id === id ? { ...phone, value, type } : phone
+      )
     );
+    localStorage.setItem('phones', JSON.stringify(phones));
   };
 
   return (
@@ -341,6 +367,7 @@ const CreateContactForm = ({
                             onChange={(e) => {
                               field.onChange(e);
                               setComment(e.target.value);
+                              localStorage.setItem('comment', e.target.value);
                             }}
                           />
                         </FormControl>

--- a/components/Forms/AddContact/CreateContactForm.tsx
+++ b/components/Forms/AddContact/CreateContactForm.tsx
@@ -33,7 +33,6 @@ const CreateContactForm = ({
 }) => {
   const dispatch = useAppDispatch();
   const [comment, setComment] = useState('');
-  const [boardId, setBoardId] = useState('');
   const [lastName, setLastName] = useState('');
   const [photoUrl, setPhotoUrl] = useState('');
   const [jobTitle, setJobTitle] = useState('');
@@ -154,12 +153,12 @@ const CreateContactForm = ({
         localStorage.setItem('facebookUrl', value);
         break;
       case 'lastName':
-        setLastName(value);
+        setLastName(value as string);
         form.setValue('lastName', value);
         localStorage.setItem('lastName', value);
         break;
       case 'firstName':
-        setFirstName(value);
+        setFirstName(value as string);
         form.setValue('firstName', value);
         localStorage.setItem('firstName', value);
         break;

--- a/components/Forms/AddContact/EmailAndPhone.tsx
+++ b/components/Forms/AddContact/EmailAndPhone.tsx
@@ -30,7 +30,7 @@ const types = [
 interface EmailAndPhoneProps {
   id: string;
   contact: 'email' | 'phone';
-  returnData: (type: 'email' | 'phone', id: string) => void;
+  returnData: (contact: 'email' | 'phone', id: string) => void;
   handleChange: (id: string, value: string, type: string) => void;
 }
 
@@ -51,16 +51,27 @@ const EmailAndPhone = ({
   const debouncedHandleChange = useCallback(
     debounce((id: string, value: string, type: string) => {
       handleChange(id, value, type);
+      // console.log('type', type, 'Value: ', value, 'id: ', id);
+
+      const storageKey = contact === 'email' ? 'emails' : 'phones';
+      const existingItems = JSON.parse(
+        localStorage.getItem(storageKey) || '[]'
+      ) as any[];
+      const updatedItems = existingItems.filter((item) => item.id !== id); // Remove any existing item with the same id
+      updatedItems.push({ id, value, type }); // Add the new item
+      localStorage.setItem(storageKey, JSON.stringify(updatedItems));
     }, 300),
-    []
+    [contact]
   );
 
   useEffect(() => {
-    debouncedHandleChange(id, inputValue, type);
+    if (inputValue || type) {
+      debouncedHandleChange(id, inputValue, type);
+    }
     return () => {
       debouncedHandleChange.cancel();
     };
-  }, [inputValue, id, debouncedHandleChange, type]);
+  }, [inputValue, id, type, debouncedHandleChange]);
 
   return (
     <div className="w-full px-2">
@@ -105,6 +116,7 @@ const EmailAndPhone = ({
                         onSelect={(currentValue) => {
                           setType(currentValue);
                           setOpen(false);
+                          debouncedHandleChange(id, inputValue, currentValue); // Ensure the type is saved when changed
                         }}
                       >
                         {type.label}

--- a/components/Forms/AddContact/EmailAndPhone.tsx
+++ b/components/Forms/AddContact/EmailAndPhone.tsx
@@ -18,12 +18,12 @@ import {
 
 const types = [
   {
-    value: 'work',
-    label: 'work',
+    value: 'WORK',
+    label: 'WORK',
   },
   {
-    value: 'personal',
-    label: 'personal',
+    value: 'PERSONAL',
+    label: 'PERSONAL',
   },
 ];
 
@@ -41,7 +41,7 @@ const EmailAndPhone = ({
   handleChange,
 }: EmailAndPhoneProps) => {
   const [open, setOpen] = useState(false);
-  const [type, setType] = useState('work');
+  const [type, setType] = useState('WORK');
   const [inputValue, setInputValue] = useState('');
 
   const removeContact = () => {
@@ -51,7 +51,6 @@ const EmailAndPhone = ({
   const debouncedHandleChange = useCallback(
     debounce((id: string, value: string, type: string) => {
       handleChange(id, value, type);
-      // console.log('type', type, 'Value: ', value, 'id: ', id);
 
       const storageKey = contact === 'email' ? 'emails' : 'phones';
       const existingItems = JSON.parse(
@@ -101,7 +100,7 @@ const EmailAndPhone = ({
                 aria-expanded={open}
                 className="w-fit justify-between !h-7 !px-2"
               >
-                {type}
+                <span className="text-xs">{type}</span>
                 <RxChevronDown className="opacity-50 ml-2" />
               </Button>
             </PopoverTrigger>
@@ -119,7 +118,7 @@ const EmailAndPhone = ({
                           debouncedHandleChange(id, inputValue, currentValue); // Ensure the type is saved when changed
                         }}
                       >
-                        {type.label}
+                        <span className="text-xs">{type.label}</span>
                       </CommandItem>
                     ))}
                   </CommandGroup>

--- a/components/HomePage/Kanban/Column/BoardColumns.tsx
+++ b/components/HomePage/Kanban/Column/BoardColumns.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useParams } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
 import { ChangeEvent, useEffect, useState } from 'react';
 
 import ThreeDotsMenu from './ThreeDotsMenu';
@@ -14,6 +14,7 @@ import { getBoards, updateColumnName } from '@/redux/boards/boardsThunk';
 import AddJobShortForm from '@/components/Forms/AddJobShort/AddJobShortForm';
 
 const BoardColumns = () => {
+  const router = useRouter();
   const { board_id } = useParams();
   const dispatch = useAppDispatch();
   const [isEditing, setIsEditing] = useState(false);
@@ -77,7 +78,11 @@ const BoardColumns = () => {
       companyName: localStorage.getItem('company'),
     };
 
-    dispatch(createJobPost(jobPost));
+    dispatch(createJobPost(jobPost)).then((result) => {
+      const newJobPostId = result.payload.id; // Assuming the payload contains the new job post
+      console.log('New job post ID: ', newJobPostId);
+      router.push(`/home/boards/${board_id}/job/${newJobPostId}/job-details`);
+    });
     dispatch(getBoards(accessToken as string));
     localStorage.setItem('boardValueChanged', 'false');
     localStorage.removeItem('jobTitle');

--- a/components/Misc/CreateContactModal.tsx
+++ b/components/Misc/CreateContactModal.tsx
@@ -1,8 +1,11 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { useParams } from 'next/navigation';
 
+import { useAppDispatch } from '@/redux/hooks';
 import { Button } from '@/components/ui/button';
+import { createContact } from '@/redux/contacts/contactsThunk';
 import AlertDialogModal from '@/components/HomePage/Boards/AlertDialogModal';
 import CreateContactForm from '@/components/Forms/AddContact/CreateContactForm';
 
@@ -23,8 +26,11 @@ const CreateContactModal = ({
   dialogTitle,
   buttonConfirm,
 }: CreateContactModalProps) => {
+  const { board_id } = useParams();
+  const dispatch = useAppDispatch();
   const [, setIsMenuOpen] = useState(false);
   const [isFormValid, setIsFormValid] = useState(false);
+  const accessToken = localStorage.getItem('accessToken');
   const [showContactModal, setShowContactModal] = useState(false);
 
   useEffect(() => {
@@ -33,17 +39,33 @@ const CreateContactModal = ({
     }
   }, [isVisible]);
 
-  const createContact = () => {
+  const createNewContact = () => {
     if (!isFormValid) return;
 
     setShowContactModal(false);
     if (onClose) onClose();
 
-    // TODO: Implement contact creation
+    const values = {
+      accessToken,
+      boardId: board_id,
+      comment: localStorage.getItem('comment'),
+      jobTitle: localStorage.getItem('jobTitle'),
+      lastName: localStorage.getItem('lastName'),
+      firstName: localStorage.getItem('firstName'),
+      gitHubUrl: localStorage.getItem('githubUrl'),
+      twitterUrl: localStorage.getItem('twitterUrl'),
+      linkedinUrl: localStorage.getItem('linkedinUrl'),
+      facebookUrl: localStorage.getItem('facebookUrl'),
+      companyLocation: localStorage.getItem('companyLocation'),
+      emails: JSON.parse(localStorage.getItem('emails') || '[]'),
+      phones: JSON.parse(localStorage.getItem('phones') || '[]'),
+    };
+
+    dispatch(createContact(values));
   };
 
   return (
-    <div className="">
+    <div>
       {showButton && (
         <Button
           variant="normal"
@@ -62,7 +84,7 @@ const CreateContactModal = ({
           open={showContactModal}
           isFormValid={isFormValid}
           contentWidth="!max-w-[910px]"
-          actionFunction={createContact}
+          actionFunction={createNewContact}
           buttonConfirm={buttonConfirm || 'Create'}
           dialogTitle={dialogTitle || 'Save New Contact'}
           onOpenChange={(open) => {

--- a/redux/contacts/contactsSlice.ts
+++ b/redux/contacts/contactsSlice.ts
@@ -1,7 +1,7 @@
 import { createSlice } from '@reduxjs/toolkit';
 
 import { RootState } from '../store';
-import { createContact } from './contactsThunk';
+import { createContact, updateContact, deleteContact } from './contactsThunk';
 
 interface ContactState {
   contacts: Contact[];
@@ -32,6 +32,34 @@ export const contactsSlice = createSlice({
       .addCase(createContact.rejected, (state, action) => {
         state.contactsStatus = 'failed';
         state.error = action.error.message || 'Failed to create contact';
+      })
+      .addCase(updateContact.pending, (state) => {
+        state.contactsStatus = 'loading';
+      })
+      .addCase(updateContact.fulfilled, (state, action) => {
+        state.contactsStatus = 'succeeded';
+        state.contacts = state.contacts.map((contact) =>
+          contact.id === action.payload.id ? action.payload : contact
+        );
+        state.error = null;
+      })
+      .addCase(updateContact.rejected, (state, action) => {
+        state.contactsStatus = 'failed';
+        state.error = action.error.message || 'Failed to update contact';
+      })
+      .addCase(deleteContact.pending, (state) => {
+        state.contactsStatus = 'loading';
+      })
+      .addCase(deleteContact.fulfilled, (state, action) => {
+        state.contactsStatus = 'succeeded';
+        state.contacts = state.contacts.filter(
+          (contact) => contact.id !== action.payload.id
+        );
+        state.error = null;
+      })
+      .addCase(deleteContact.rejected, (state, action) => {
+        state.contactsStatus = 'failed';
+        state.error = action.error.message || 'Failed to delete contact';
       });
   },
 });

--- a/redux/contacts/contactsThunk.ts
+++ b/redux/contacts/contactsThunk.ts
@@ -2,7 +2,7 @@ import client from '@/api/client';
 import { createAsyncThunk } from '@reduxjs/toolkit';
 
 export const createContact = createAsyncThunk(
-  'contacts',
+  'contacts/createContact',
   async (values: any, thunkAPI) => {
     const {
       emails,
@@ -54,7 +54,7 @@ export const createContact = createAsyncThunk(
 );
 
 export const updateContact = createAsyncThunk(
-  'contacts',
+  'contacts/updateContact',
   async (values: any, thunkAPI) => {
     const {
       id,
@@ -108,7 +108,7 @@ export const updateContact = createAsyncThunk(
 );
 
 export const deleteContact = createAsyncThunk(
-  'contacts',
+  'contacts/deleteContact',
   async (values: any, thunkAPI) => {
     const { id, accessToken } = values;
     try {

--- a/redux/contacts/contactsThunk.ts
+++ b/redux/contacts/contactsThunk.ts
@@ -52,3 +52,77 @@ export const createContact = createAsyncThunk(
     }
   }
 );
+
+export const updateContact = createAsyncThunk(
+  'contacts',
+  async (values: any, thunkAPI) => {
+    const {
+      id,
+      emails,
+      phones,
+      boardId,
+      comment,
+      lastName,
+      photoUrl,
+      jobTitle,
+      companies,
+      firstName,
+      gitHubUrl,
+      twitterUrl,
+      linkedinUrl,
+      accessToken,
+      facebookUrl,
+      companyLocation,
+    } = values;
+    const body = {
+      id,
+      emails,
+      phones,
+      boardId,
+      comment,
+      photoUrl,
+      lastName,
+      jobTitle,
+      firstName,
+      gitHubUrl,
+      companies,
+      twitterUrl,
+      linkedinUrl,
+      facebookUrl,
+      companyLocation,
+    };
+    try {
+      const res = await client.put(`/contacts`, body, {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+      const data = res.data;
+      return data;
+    } catch (err: any) {
+      return thunkAPI.rejectWithValue(
+        err.response?.data || 'Error updating contact'
+      );
+    }
+  }
+);
+
+export const deleteContact = createAsyncThunk(
+  'contacts',
+  async (values: any, thunkAPI) => {
+    const { id, accessToken } = values;
+    try {
+      const res = await client.delete(`/contacts/${id}`, {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+      const data = res.data;
+      return data;
+    } catch (err: any) {
+      return thunkAPI.rejectWithValue(
+        err.response?.data || 'Error deleting contact'
+      );
+    }
+  }
+);

--- a/redux/contacts/contactsThunk.ts
+++ b/redux/contacts/contactsThunk.ts
@@ -10,9 +10,9 @@ export const createContact = createAsyncThunk(
       boardId,
       comment,
       lastName,
-      photoUrl,
+      // photoUrl,
       jobTitle,
-      companies,
+      // companies,
       firstName,
       gitHubUrl,
       twitterUrl,
@@ -22,20 +22,20 @@ export const createContact = createAsyncThunk(
       companyLocation,
     } = values;
     const body = {
-      emails,
-      phones,
-      boardId,
-      comment,
-      photoUrl,
-      lastName,
-      jobTitle,
-      firstName,
-      gitHubUrl,
-      companies,
-      twitterUrl,
-      linkedinUrl,
-      facebookUrl,
-      companyLocation,
+      emails: emails,
+      phones: phones,
+      boardId: boardId,
+      comment: comment,
+      // photoUrl: photoUrl,
+      lastName: lastName,
+      jobTitle: jobTitle,
+      firstName: firstName,
+      gitHubUrl: gitHubUrl,
+      // companies: companies,
+      twitterUrl: twitterUrl,
+      linkedinUrl: linkedinUrl,
+      facebookUrl: facebookUrl,
+      companyLocation: companyLocation,
     };
     try {
       const res = await client.post(`/contacts`, body, {
@@ -44,6 +44,7 @@ export const createContact = createAsyncThunk(
         },
       });
       const data = res.data;
+      console.log('Data from thunk: ', data);
       return data;
     } catch (err: any) {
       return thunkAPI.rejectWithValue(

--- a/redux/user/userThunk.ts
+++ b/redux/user/userThunk.ts
@@ -34,13 +34,26 @@ export const login = createAsyncThunk(
 
 export const logout = createAsyncThunk('user/logout', async () => {
   localStorage.removeItem('user');
+  localStorage.removeItem('emails');
+  localStorage.removeItem('phones');
+  localStorage.removeItem('comment');
+  localStorage.removeItem('jobTitle');
   localStorage.removeItem('columnId');
+  localStorage.removeItem('lastName');
+  localStorage.removeItem('gitHubUrl');
+  localStorage.removeItem('companies');
+  localStorage.removeItem('firstName');
+  localStorage.removeItem('twitterUrl');
+  localStorage.removeItem('linkedinUrl');
   localStorage.removeItem('chosenBoard');
   localStorage.removeItem('accessToken');
+  localStorage.removeItem('facebookUrl');
   localStorage.removeItem('refreshToken');
   localStorage.removeItem('chosenColumn');
+  localStorage.removeItem('companyLocation');
   localStorage.removeItem('boardValueChanged');
   localStorage.removeItem('firstColumnOfTheBoard');
+  localStorage.removeItem('jobsConnectedToContact');
 
   return {
     email: '',

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -31,13 +31,13 @@ type Notes = {
 type Email = {
   id: string;
   email: string;
-  type: 'work' | 'personal';
+  type: 'WORK' | 'PERSONAL';
 };
 
 type Phone = {
   id: string;
   phone: string;
-  type: 'work' | 'personal';
+  type: 'WORK' | 'PERSONAL';
 };
 
 type Contact = {


### PR DESCRIPTION
Add redirect to job details after a new job creation from AddJobShortForm modal to the JobPost Modal.
Add updateContact and deleteContact action to the Thunk and Slice.
Save all the parameters for new Contact in localStorage. Clean up the storage on logout. Ther might be some issues with emails and phones - the arrays consist of three elements: id, value and type. Needs to clarify with back end.
Implement createNewContact in CreateContactModal. Basic action with firstName, lastName, jobtitle, comment, etc. is working.