### PR TITLE
fix: a bug not showing job posts assigned to a contact

### DIFF
--- a/app/(loggedin)/home/boards/[board_id]/contacts/page.tsx
+++ b/app/(loggedin)/home/boards/[board_id]/contacts/page.tsx
@@ -15,11 +15,9 @@ const BoardContacts = () => {
 
   const fetchBoardContacts = useCallback(async () => {
     try {
-      console.log('Fetching board contacts...'); // Debug log
       const contacts = await dispatch(
-        getAllContactsPerBoard({ accessToken, boardId: board_id })
+        getAllContactsPerBoard({ accessToken, boardId: board_id }),
       ).unwrap();
-      console.log('Fetched contacts:', contacts); // Debug log
       setAllBoardContacts(contacts);
     } catch (error) {
       console.error('Error fetching board contacts:', error);

--- a/components/Forms/AddContact/ContactSideBar.tsx
+++ b/components/Forms/AddContact/ContactSideBar.tsx
@@ -42,9 +42,8 @@ const ContactSideBar = ({
       }
     };
     fetchBoardJobs();
-  }, [board_id, dispatch, accessToken]);
-
-  useEffect(() => {
+  }, [board_id, dispatch, accessToken]);  useEffect(() => {
+    // Only auto-assign job when coming from job post modal (job_id exists)
     if (job_id) {
       const currentJob = jobs.jobPosts.find(
         (job: JobApplication) => job.id === job_id
@@ -52,9 +51,9 @@ const ContactSideBar = ({
       if (currentJob) {
         onJobsChange([currentJob]);
       }
-    } else {
-      onJobsChange([]);
     }
+    // Don't clear jobs when job_id is empty - this preserves existing assignments
+    // when opening modal from contacts page
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [job_id, jobs.jobPosts]);
 

--- a/components/Forms/AddContact/ContactSideBar.tsx
+++ b/components/Forms/AddContact/ContactSideBar.tsx
@@ -54,8 +54,7 @@ const ContactSideBar = ({
     }
     // Don't clear jobs when job_id is empty - this preserves existing assignments
     // when opening modal from contacts page
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [job_id, jobs.jobPosts]);
+  }, [job_id, jobs.jobPosts, onJobsChange]);
 
   const handleAddJob = (jobTitle: string, jobId: string) => {
     const jobsList = board_id ? boardJobs : jobs.jobPosts;

--- a/components/Forms/AddContact/CreateContactForm.tsx
+++ b/components/Forms/AddContact/CreateContactForm.tsx
@@ -392,6 +392,13 @@ const CreateContactForm = ({
     fetchJobs();
   }, [dispatch, accessToken, defaultJobPost, board_id, isUserContactsPage]);
 
+  // Sync allJobPosts with Redux jobs to ensure sidebar always has access to jobs
+  useEffect(() => {
+    if (jobs.jobPosts.length > 0 && allJobPosts.length === 0) {
+      setAllJobPosts(jobs.jobPosts);
+    }
+  }, [jobs.jobPosts, allJobPosts.length]);
+
   useEffect(() => {
     if (selectedCompanyName) {
       setCompanies([selectedCompanyName]);

--- a/components/Forms/AddContact/CreateContactForm.tsx
+++ b/components/Forms/AddContact/CreateContactForm.tsx
@@ -391,13 +391,12 @@ const CreateContactForm = ({
 
     fetchJobs();
   }, [dispatch, accessToken, defaultJobPost, board_id, isUserContactsPage]);
-
   // Sync allJobPosts with Redux jobs to ensure sidebar always has access to jobs
   useEffect(() => {
-    if (jobs.jobPosts.length > 0 && allJobPosts.length === 0) {
+    if (jobs.jobPosts.length && jobs.jobPosts.length !== allJobPosts.length) {
       setAllJobPosts(jobs.jobPosts);
     }
-  }, [jobs.jobPosts, allJobPosts.length]);
+  }, [jobs.jobPosts.length, allJobPosts.length]); // track only the lengths
 
   useEffect(() => {
     if (selectedCompanyName) {

--- a/components/Misc/ContactsList.tsx
+++ b/components/Misc/ContactsList.tsx
@@ -19,7 +19,7 @@ const ContactsList = ({
   const [error, setError] = useState<string | null>(null);
   const isContactsPage = pathname?.includes('/home/contacts');
   const [contactsWithBoardIds, setContactsWithBoardIds] = useState<Contact[]>(
-    initialContacts || []
+    initialContacts || [],
   );
   const board_id = params.board_id
     ? Array.isArray(params.board_id)
@@ -35,7 +35,7 @@ const ContactsList = ({
           getAllContactsPerBoard({
             accessToken,
             boardId,
-          })
+          }),
         ).unwrap();
 
         return boardContacts.map((contact: Contact) => ({
@@ -47,19 +47,19 @@ const ContactsList = ({
         return [];
       }
     },
-    [dispatch, accessToken]
+    [dispatch, accessToken],
   );
 
   // Fetch contacts from all boards
   const fetchAllContacts = useCallback(async () => {
     try {
       const boards = await dispatch(
-        getBoardsOnly(accessToken as string)
+        getBoardsOnly(accessToken as string),
       ).unwrap();
 
       // Fetch contacts for all boards in parallel
       const contactPromises = boards.map((board: Board) =>
-        fetchContactsForBoard(board.id)
+        fetchContactsForBoard(board.id),
       );
 
       // Wait for all promises to resolve
@@ -112,32 +112,23 @@ const ContactsList = ({
   // Handle data refresh separately to avoid creating loops
   useEffect(() => {
     if (refetchContacts) {
-      console.log('Refetching contacts...');
       refetchContacts();
     }
   }, [refetchContacts]);
 
-  useEffect(() => {
-    console.log('Updated contactsWithBoardIds:', contactsWithBoardIds); // Debug log
-  }, [contactsWithBoardIds]);
   const handleContactDeleted = (deletedContactId: string) => {
     setContactsWithBoardIds((prevContacts) =>
-      prevContacts.filter((contact) => contact.id !== deletedContactId)
+      prevContacts.filter((contact) => contact.id !== deletedContactId),
     );
   };
 
   const handleContactUpdated = (updatedContact: Contact) => {
     setContactsWithBoardIds((prevContacts) =>
       prevContacts.map((contact) =>
-        contact.id === updatedContact.id ? updatedContact : contact
-      )
+        contact.id === updatedContact.id ? updatedContact : contact,
+      ),
     );
   };
-
-  useEffect(() => {
-    console.log('Initial contacts updated:', initialContacts); // Debug log
-    setContactsWithBoardIds(initialContacts || []);
-  }, [initialContacts]);
 
   return (
     <div className="w-2/3 flex flex-col mx-auto mt-8">
@@ -151,8 +142,8 @@ const ContactsList = ({
             onContactUpdated={(updatedContact) => {
               setContactsWithBoardIds((prevContacts) =>
                 prevContacts.map((contact) =>
-                  contact.id === updatedContact.id ? updatedContact : contact
-                )
+                  contact.id === updatedContact.id ? updatedContact : contact,
+                ),
               );
             }}
           />
@@ -181,13 +172,14 @@ const ContactsList = ({
         </div>
       )}
 
-      {!isLoading && !error && contactsWithBoardIds.length > 0 && (        <div className="w-full flex flex-wrap items-center justify-start gap-4 max-h-[80vh] overflow-y-auto">
+      {!isLoading && !error && contactsWithBoardIds.length > 0 && (
+        <div className="w-full flex flex-wrap items-center justify-start gap-4 max-h-[80vh] overflow-y-auto">
           {contactsWithBoardIds.map((contact) => (
             <div key={contact.id}>
-              <ContactCard 
-                contact={contact} 
+              <ContactCard
+                contact={contact}
                 onDelete={handleContactDeleted}
-                onUpdate={handleContactUpdated} 
+                onUpdate={handleContactUpdated}
               />
             </div>
           ))}


### PR DESCRIPTION
There was a problem when a contact is opened for edit from the user's contacts page or from a board's contacts page. The problem was that the job applications assigned to this contact are not shown. Initially they were rendered, but because of timing issue and not synchronizing the `allJobPosts` with redux jobs they were removed from the side bar.
This PR fix this problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved existing job assignments when opening the contact modal from the contacts page, preventing unintended clearing of jobs.

- **New Features**
  - Ensured the sidebar always has access to the latest jobs data by synchronizing local state with updates from the job list.

- **Style**
  - Improved code formatting and consistency for better readability; removed unnecessary debug statements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->