### PR TITLE
fix: delete a document from user's documents page was not allowed

### DIFF
--- a/app/(loggedin)/home/boards/[board_id]/documents/page.tsx
+++ b/app/(loggedin)/home/boards/[board_id]/documents/page.tsx
@@ -195,6 +195,37 @@ const BoardDocuments = () => {
     }
   };
 
+  const openDocumentInNewTab = (url: string) => {
+    return window.open(url, '_blank', 'noopener,noreferrer');
+  };
+
+  const handlePopupBlocker = (url: string, title: string) => {
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = title || 'document';
+    link.target = '_blank';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    toast.success('Document download initiated');
+  };
+
+  const checkTabStatusWithTimeout = (newTab: Window) => {
+    const timeoutId = setTimeout(() => {
+      try {
+        if (newTab && !newTab.closed) {
+          toast.success('Document opened in new tab');
+        } else {
+          toast.success('Document has been downloaded');
+        }
+      } catch (error) {
+        console.warn('Could not check tab status:', error);
+        toast.success('Document has been processed');
+      }
+    }, 1000);
+    return timeoutId;
+  };
+
   const handleDownloadDocument = async (jobDocument: JobDocument) => {
     try {
       if (!jobDocument.url) {
@@ -202,39 +233,12 @@ const BoardDocuments = () => {
         return;
       }
 
-      // Try to open in new tab, with fallback for popup blockers
-      const newTab = window.open(
-        jobDocument.url,
-        '_blank',
-        'noopener,noreferrer'
-      );
+      const newTab = openDocumentInNewTab(jobDocument.url);
 
-      // Handle popup blocker case
       if (!newTab || newTab.closed || typeof newTab.closed === 'undefined') {
-        // Fallback: Create a download link
-        const link = document.createElement('a');
-        link.href = jobDocument.url;
-        link.download = jobDocument.title || 'document';
-        link.target = '_blank';
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
-        toast.success('Document download initiated');
+        handlePopupBlocker(jobDocument.url, jobDocument.title);
       } else {
-        // Use a more robust approach with proper error handling and longer timeout
-        const checkTabStatus = setTimeout(() => {
-          try {
-            if (newTab && !newTab.closed) {
-              toast.success('Document opened in new tab');
-            } else {
-              toast.success('Document has been downloaded');
-            }
-          } catch (error) {
-            // Tab may be closed, cross-origin, or inaccessible
-            console.warn('Could not check tab status:', error);
-            toast.success('Document has been processed');
-          }
-        }, 1000);
+        checkTabStatusWithTimeout(newTab);
       }
     } catch (error) {
       console.error('Error opening document:', error);

--- a/app/(loggedin)/home/documents/page.tsx
+++ b/app/(loggedin)/home/documents/page.tsx
@@ -73,10 +73,10 @@ const UserDocuments = () => {
         });
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     dispatch,
     accessToken,
-    uploaderInfo,
     user.lastName,
     user.firstName,
     user.profilePicUrl,
@@ -131,26 +131,8 @@ const UserDocuments = () => {
         return;
       }
 
-      // For user documents, check if document is attached to job applications
-      const documentDetailsResult = await dispatch(
-        getDocument({
-          documentId,
-          accessToken: accessToken as string,
-        })
-      ).unwrap();
-
-      const jobApplicationsCount =
-        documentDetailsResult.jobApplications?.length || 0;
-
-      // If attached to job applications, warn user
-      if (jobApplicationsCount > 0) {
-        toast.info(
-          'This document is attached to job applications. Delete it from those jobs first.'
-        );
-        return;
-      }
-
-      // Delete the document entirely since it's not attached to any job applications
+      // For user documents, always delete the document entirely from the database
+      // This will automatically detach it from all job applications and remove it completely
       await dispatch(
         deleteDocument({
           documentId,
@@ -182,8 +164,7 @@ const UserDocuments = () => {
       if (
         !newTab ||
         newTab.closed ||
-        typeof newTab.closed === 'undefined' ||
-        !newTab.location
+        typeof newTab.closed === 'undefined'
       ) {
         // Fallback: Create a download link for popup blocker case
         const link = document.createElement('a');


### PR DESCRIPTION
Fix a issue preventing the user to delete a document, when it is attached to the job application from the User's documents page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the document download experience with more robust handling of popup blockers and tab status, providing clearer user feedback.
  * Simplified document deletion so that documents are always deleted, with backend handling any necessary detachment from job applications.
* **Bug Fixes**
  * Reduced unnecessary re-renders when setting uploader information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->