### PR TITLE
feat: implement edit document functionality

### DIFF
--- a/app/(loggedin)/home/boards/[board_id]/job/[job_id]/job-details/page.tsx
+++ b/app/(loggedin)/home/boards/[board_id]/job/[job_id]/job-details/page.tsx
@@ -37,13 +37,14 @@ const JobDetails = () => {
     dispatch(getAllJobApplicationNotes(updatePayload));
   }, [accessToken, dispatch, job_id]);
 
+  // TODO: Maybe make it the same way as Documents and Contacts
   const numberOfNotes = notes.length;
 
   const numberOfContactsPerJob = jobs.jobPosts.find((job) => job.id === job_id)
     ?.contacts.length;
 
-  const numberOfDocumentsPerJob = jobs.jobPosts.find((job) => job.id === job_id)
-    ?.documents.length || 0;
+  const numberOfDocumentsPerJob =
+    jobs.jobPosts.find((job) => job.id === job_id)?.documents.length || 0;
 
   return (
     <Tabs defaultValue="Job Info" className="w-full">

--- a/components/Forms/AddDocument/EditDocumentModal.tsx
+++ b/components/Forms/AddDocument/EditDocumentModal.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import { toast } from 'react-toastify';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+
+import Modal from '@/components/Misc/Modal';
+import { EditDocumentSchema } from '@/schemas';
+import { useAppDispatch } from '@/redux/hooks';
+import { Button } from '@/components/ui/button';
+import { updateDocument } from '@/redux/documents/documentsThunk';
+
+interface EditDocumentsProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onEditSuccess: () => void;
+  documentToEdit: JobDocument;
+}
+
+const EditDocumentModal = ({
+  isOpen,
+  onClose,
+  onEditSuccess,
+  documentToEdit,
+}: EditDocumentsProps) => {
+  const dispatch = useAppDispatch();
+  const accessToken = localStorage.getItem('accessToken');
+
+  const form = useForm({
+    resolver: zodResolver(EditDocumentSchema),
+    defaultValues: {
+      title: documentToEdit.title || '',
+      category: documentToEdit.category || '',
+      description: documentToEdit.description || '',
+    },
+  });
+
+  const handleSubmit = async (data: any) => {
+    try {
+      if (!accessToken) {
+        toast.error('Authentication required');
+        return;
+      }
+
+      // Use the title exactly as entered by the user
+      const newTitle = data.title;
+
+      await dispatch(
+        updateDocument({
+          accessToken,
+          title: newTitle,
+          category: data.category,
+          documentId: documentToEdit.id,
+          description: data.description,
+        })
+      ).unwrap();
+
+      toast.success('Document updated successfully!');
+      onEditSuccess();
+    } catch (error) {
+      console.error('Error updating document:', error);
+      toast.error('Failed to update document. Please try again.');
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <Modal stylings="sm:w-11/12 md:w-3/4 lg:w-2/3 xl:w-[960px] bg-white">
+      <div className="min-h-[840px]">
+        <div className="flex justify-between items-center p-4 border-b w-full mb-8">
+          <h1 className="text-xl font-semibold mb-4">Edit Document</h1>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              onClick={() => window.open(documentToEdit.url, '_blank')}
+            >
+              Download
+            </Button>
+            <Button variant="outline" onClick={onClose}>
+              Cancel
+            </Button>
+          </div>
+        </div>
+        <div className="px-4">
+          <form onSubmit={form.handleSubmit(handleSubmit)}>
+            <div className="mb-4">
+              <label className="block text-sm font-medium mb-2">Title</label>
+              <input
+                {...form.register('title')}
+                placeholder="Document Title"
+                className="w-full p-2 border rounded"
+              />
+            </div>
+            <div className="mb-4">
+              <label className="block text-sm font-medium mb-2">Category</label>
+              <input
+                {...form.register('category')}
+                placeholder="Document Category"
+                className="w-full p-2 border rounded"
+              />
+            </div>
+            <div className="mb-4">
+              <label className="block text-sm font-medium mb-2">
+                Description
+              </label>
+              <textarea
+                {...form.register('description')}
+                placeholder="Document Description"
+                className="w-full p-2 border rounded"
+                rows={3}
+              />
+            </div>
+            <div className="flex justify-end gap-2 mt-6">
+              <Button type="button" variant="outline" onClick={onClose}>
+                Cancel
+              </Button>
+              <Button type="submit">Save Changes</Button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default EditDocumentModal;

--- a/components/Forms/AddDocument/UploadDocumentModal.tsx
+++ b/components/Forms/AddDocument/UploadDocumentModal.tsx
@@ -35,16 +35,6 @@ const validateFileSize = (file: File): boolean => {
   return true;
 };
 
-interface UploadDocumentModalProps {
-  isVisible?: boolean;
-  onClose?: () => void;
-  showButton?: boolean;
-  buttonLabel?: string;
-  dialogTitle?: string;
-  defaultJobId?: string;
-  onUploadSuccess?: () => void;
-}
-
 const UploadDocumentModal = ({
   onClose,
   isVisible,

--- a/components/HomePage/Kanban/Column/BoardColumns.tsx
+++ b/components/HomePage/Kanban/Column/BoardColumns.tsx
@@ -6,13 +6,13 @@ import { ChangeEvent, useEffect, useState } from 'react';
 import ThreeDotsMenu from './ThreeDotsMenu';
 import { Input } from '@/components/ui/input';
 import JobPostCard from './JobPosts/JobPostCard';
+import { cleanupAfterJobPost } from '@/utils/helpers';
 import { returnBoardIcon } from '@/utils/ReturnIcons';
 import { createJobPost } from '@/redux/jobs/jobsThunk';
 import AlertDialogModal from '../../Boards/AlertDialogModal';
 import { useAppDispatch, useAppSelector } from '@/redux/hooks';
 import { getBoards, updateColumnName } from '@/redux/boards/boardsThunk';
 import AddJobShortForm from '@/components/Forms/AddJobShort/AddJobShortForm';
-import { cleanupAfterJobPost } from '@/utils/helpers';
 
 const BoardColumns = () => {
   const router = useRouter();

--- a/components/HomePage/Kanban/Column/JobPosts/JobModal/JobDocuments/DocumentCard.tsx
+++ b/components/HomePage/Kanban/Column/JobPosts/JobModal/JobDocuments/DocumentCard.tsx
@@ -14,12 +14,16 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 
+type ExtendedJobDocument = JobDocument & {
+  extension?: string;
+};
+
 const DocumentCard = ({
-  document,
   onEdit,
+  document,
   onDelete,
   onDownload,
-}: DocumentCardProps) => {
+}: DocumentCardProps & { document: ExtendedJobDocument }) => {
   const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
 
   const timeAgo = getTimeAgo(document.createdAt || document.updatedAt || '');
@@ -35,20 +39,14 @@ const DocumentCard = ({
     }
   };
 
-  // Simple and reliable file extension detection
+  // File extension/type is determined from the original file name (title at upload)
   const getFileExtensionInfo = () => {
-    // Use title as the filename (it should contain the full filename with extension)
-    const filename = document.title || '';
-
-    // Extract extension from filename - case insensitive
+    // Always parse extension from the original file name (title at upload)
+    const filename = document.originalFileName || document.title || '';
     const extensionMatch = filename.match(/\.([^.]+)$/i);
-
     if (extensionMatch) {
       const ext = extensionMatch[1].toLowerCase();
-
-      // Map extensions to display types consistently
       let displayType = ext.toUpperCase();
-
       switch (ext) {
         case 'jpg':
         case 'jpeg':
@@ -85,39 +83,15 @@ const DocumentCard = ({
         default:
           displayType = ext.toUpperCase();
       }
-
       return {
         extension: ext,
-        isLegacy: false,
         extensionUpper: displayType,
       };
     }
-
-    // No extension found - use category as fallback
-    let defaultExt = 'file';
-    let defaultDisplay = 'FILE';
-
-    switch (document.category) {
-      case 'Resume':
-      case 'Portfolio':
-      case 'Transcript':
-      case 'Certification':
-        defaultExt = 'pdf';
-        defaultDisplay = 'PDF';
-        break;
-      case 'Cover Letter':
-        defaultExt = 'doc';
-        defaultDisplay = 'DOC';
-        break;
-      default:
-        defaultExt = 'file';
-        defaultDisplay = 'FILE';
-    }
-
+    // If all else fails, use FILE
     return {
-      isLegacy: true,
-      extension: defaultExt,
-      extensionUpper: defaultDisplay,
+      extension: 'file',
+      extensionUpper: 'FILE',
     };
   };
 
@@ -232,7 +206,7 @@ const DocumentCard = ({
           <DropdownMenuContent align="end">
             {onEdit && (
               <DropdownMenuItem onClick={() => onEdit(document)}>
-                Edit
+                Edit Document
               </DropdownMenuItem>
             )}
             {onDownload && (

--- a/components/HomePage/Kanban/Column/JobPosts/JobModal/JobDocuments/DocumentCard.tsx
+++ b/components/HomePage/Kanban/Column/JobPosts/JobModal/JobDocuments/DocumentCard.tsx
@@ -42,7 +42,7 @@ const DocumentCard = ({
   // File extension/type is determined from the original file name (title at upload)
   const getFileExtensionInfo = () => {
     // Always parse extension from the original file name (title at upload)
-    const filename = document.originalFileName || document.title || '';
+    const filename = document.title || '';
     const extensionMatch = filename.match(/\.([^.]+)$/i);
     if (extensionMatch) {
       const ext = extensionMatch[1].toLowerCase();

--- a/components/HomePage/Kanban/Column/JobPosts/JobModal/JobDocuments/Documents.tsx
+++ b/components/HomePage/Kanban/Column/JobPosts/JobModal/JobDocuments/Documents.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { toast } from 'react-toastify';
-import { useEffect, useState, useMemo } from 'react';
 import { useParams } from 'next/navigation';
+import { useEffect, useState, useMemo } from 'react';
 
 import DocumentCard from './DocumentCard';
 import { getUser } from '@/redux/user/userThunk';
@@ -18,12 +18,18 @@ import {
   attachDocumentToJobApplication,
   detachDocumentFromJobApplication,
 } from '@/redux/documents/documentsThunk';
+import { set } from 'lodash';
+import EditDocumentModal from '@/components/Forms/AddDocument/EditDocumentModal';
 
 const Documents = () => {
   const { job_id } = useParams();
   const dispatch = useAppDispatch();
   const jobs = useAppSelector((state) => state.jobs);
   const user = useAppSelector((state) => state.user);
+  const userDocuments = useAppSelector(selectUserDocuments);
+  const [isUploadModalOpen, setIsUploadModalOpen] = useState(false);
+  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+  const [documentToEdit, setDocumentToEdit] = useState<JobDocument | null>(null);
   const accessToken = (() => {
     try {
       return localStorage.getItem('accessToken');
@@ -32,7 +38,6 @@ const Documents = () => {
       return null;
     }
   })();
-  const userDocuments = useAppSelector(selectUserDocuments);
   const [uploaderInfo, setUploaderInfo] = useState<{
     lastName: string;
     firstName: string;
@@ -129,11 +134,12 @@ const Documents = () => {
   };
 
   // Filter out documents that are already attached to current job (memoized for performance)
-  const availableDocuments = useMemo(() =>
-    userDocuments.filter(
-      (document) =>
-        !jobDocuments.some((attachedDoc) => attachedDoc.id === document.id)
-    ),
+  const availableDocuments = useMemo(
+    () =>
+      userDocuments.filter(
+        (document) =>
+          !jobDocuments.some((attachedDoc) => attachedDoc.id === document.id)
+      ),
     [userDocuments, jobDocuments]
   );
 
@@ -146,9 +152,8 @@ const Documents = () => {
   });
 
   const handleEditDocument = (document: JobDocument) => {
-    // TODO: Implement edit functionality - Allow users to edit document metadata (title, category, description)
-    // This should open a modal similar to UploadDocumentModal but for editing existing documents
-    toast.info('Document editing functionality will be implemented soon');
+    setDocumentToEdit(document);
+    setIsEditModalOpen(true);
   };
 
   const handleDeleteDocument = async (documentId: string) => {
@@ -292,6 +297,23 @@ const Documents = () => {
           </div>
         )}
       </div>
+
+      {/* Edit Document Modal */}
+      {isEditModalOpen && documentToEdit && (
+        <EditDocumentModal
+          isOpen={isEditModalOpen}
+          documentToEdit={documentToEdit}
+          onEditSuccess={async () => {
+            await handleDocumentsRefresh();
+            setIsEditModalOpen(false);
+            setDocumentToEdit(null);
+          }}
+          onClose={() => {
+            setIsEditModalOpen(false);
+            setDocumentToEdit(null);
+          }}
+        />
+      )}
     </>
   );
 };

--- a/components/Misc/Modal.tsx
+++ b/components/Misc/Modal.tsx
@@ -2,7 +2,7 @@
 
 import { cn } from '@/lib/utils';
 import { useRouter } from 'next/navigation';
-import { useCallback, useRef, useEffect, MouseEventHandler } from 'react';
+import { useRef, useEffect, useCallback, MouseEventHandler } from 'react';
 
 const Modal = ({
   children,
@@ -11,19 +11,36 @@ const Modal = ({
   children: React.ReactNode;
   stylings: string;
 }) => {
-  const overlay = useRef(null);
-  const wrapper = useRef(null);
   const router = useRouter();
+  const mouseDownInside = useRef(false);
+  const overlay = useRef<HTMLDivElement>(null);
+  const wrapper = useRef<HTMLDivElement>(null);
+  // Track if mousedown started inside modal
 
   const onDismiss = useCallback(() => {
     router.back();
   }, [router]);
 
+  // On mousedown, track if it started inside the modal content
+  const onMouseDown: MouseEventHandler = useCallback((e) => {
+    if (wrapper.current && wrapper.current.contains(e.target as Node)) {
+      mouseDownInside.current = true;
+    } else {
+      mouseDownInside.current = false;
+    }
+  }, []);
+
+  // On click (mouseup), only close if mousedown did NOT start inside
   const onClick: MouseEventHandler = useCallback(
     (e) => {
-      if (e.target === overlay.current || e.target === wrapper.current) {
+      if (
+        (e.target === overlay.current || e.target === wrapper.current) &&
+        !mouseDownInside.current
+      ) {
         if (onDismiss) onDismiss();
       }
+      // Always reset after click
+      mouseDownInside.current = false;
     },
     [onDismiss, overlay, wrapper]
   );
@@ -43,8 +60,9 @@ const Modal = ({
   return (
     <div
       ref={overlay}
-      className="fixed z-10 left-0 right-0 top-0 bottom-0 mx-auto bg-black/60 p-10"
       onClick={onClick}
+      onMouseDown={onMouseDown}
+      className="fixed z-10 left-0 right-0 top-0 bottom-0 mx-auto bg-black/60 p-10"
     >
       <div
         ref={wrapper}

--- a/redux/documents/documentsSlice.ts
+++ b/redux/documents/documentsSlice.ts
@@ -4,6 +4,7 @@ import { RootState } from '../store';
 import {
   getDocument,
   uploadDocument,
+  updateDocument,
   deleteDocument,
   getDocumentsPerUser,
   getDocumentsPerBoard,
@@ -140,6 +141,23 @@ const documentsSlice = createSlice({
       .addCase(getDocumentsPerBoard.rejected, (state, action) => {
         state.boardDocumentsStatus = 'failed';
         state.error = action.error.message || 'Failed to fetch board documents';
+      })
+      .addCase(updateDocument.pending, (state) => {
+        state.documentsStatus = 'loading';
+      })
+      .addCase(updateDocument.fulfilled, (state, action) => {
+        state.documentsStatus = 'succeeded';
+        const index = state.documents.findIndex(
+          (doc) => doc.id === action.payload.id
+        );
+        if (index >= 0) {
+          state.documents[index] = action.payload;
+        }
+        state.error = null;
+      })
+      .addCase(updateDocument.rejected, (state, action) => {
+        state.documentsStatus = 'failed';
+        state.error = action.error.message || 'Failed to update document';
       });
   },
 });
@@ -148,9 +166,11 @@ export default documentsSlice.reducer;
 export const selectDocuments = (state: RootState) => state.documents.documents;
 export const selectDocumentsStatus = (state: RootState) =>
   state.documents.documentsStatus;
-export const selectUserDocuments = (state: RootState) => state.documents.userDocuments;
+export const selectUserDocuments = (state: RootState) =>
+  state.documents.userDocuments;
 export const selectUserDocumentsStatus = (state: RootState) =>
   state.documents.userDocumentsStatus;
-export const selectBoardDocuments = (state: RootState) => state.documents.boardDocuments;
+export const selectBoardDocuments = (state: RootState) =>
+  state.documents.boardDocuments;
 export const selectBoardDocumentsStatus = (state: RootState) =>
   state.documents.boardDocumentsStatus;

--- a/redux/documents/documentsThunk.ts
+++ b/redux/documents/documentsThunk.ts
@@ -156,3 +156,40 @@ export const getDocumentsPerBoard = createAsyncThunk(
     }
   }
 );
+
+export const updateDocument = createAsyncThunk(
+  'documents/updateDocument',
+  async (
+    values: {
+      title: string;
+      category: string;
+      documentId: string;
+      accessToken: string;
+      description?: string;
+    },
+    thunkAPI
+  ) => {
+    const { documentId, title, category, description, accessToken } = values;
+    try {
+      const formData = new FormData();
+      formData.append('title', title);
+      formData.append('category', category);
+      if (description) {
+        formData.append('description', description);
+      }
+
+      const res = await client.patch(`/documents/${documentId}`, formData, {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          'Content-Type': 'multipart/form-data',
+        },
+      });
+      const data = res.data;
+      return data;
+    } catch (err: any) {
+      return thunkAPI.rejectWithValue(
+        err.response?.data || 'Error updating document'
+      );
+    }
+  }
+);

--- a/schemas/index.ts
+++ b/schemas/index.ts
@@ -100,3 +100,9 @@ export const EditCompanySchema = z.object({
     .or(z.literal(''))
     .optional(),
 });
+
+export const EditDocumentSchema = z.object({
+  title: z.string().min(1, 'Document title is required'),
+  category: z.string().min(1, 'Document category is required'),
+  description: z.string().or(z.literal('')).optional(),
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -323,3 +323,13 @@ interface DocumentCardProps {
   onEdit?: (document: JobDocument) => void;
   onDownload?: (document: JobDocument) => void;
 }
+
+interface UploadDocumentModalProps {
+  isVisible?: boolean;
+  onClose?: () => void;
+  showButton?: boolean;
+  buttonLabel?: string;
+  dialogTitle?: string;
+  defaultJobId?: string;
+  onUploadSuccess?: () => void;
+}


### PR DESCRIPTION
The feature of editing document is implement. There is a glitch with the change of file extension, but it will be fixed, once the backend return the file extension in the response of `getDocument` request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to edit existing documents directly from the documents list, including a new modal for editing document details.
  * Introduced validation for editing documents to ensure required fields are completed.

* **Improvements**
  * Enhanced modal dismissal behavior to prevent accidental closures when interacting inside the modal.
  * Simplified and standardized file extension display for document cards.
  * Improved organization of document-related props and types for clarity.

* **Bug Fixes**
  * Fixed document editing dropdown label to clearly indicate "Edit Document".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->