### PR TITLE
fix: add cache-control and cache-busting query param

### DIFF
--- a/components/HomePage/Kanban/Column/JobPosts/JobModal/JobDocuments/Documents.tsx
+++ b/components/HomePage/Kanban/Column/JobPosts/JobModal/JobDocuments/Documents.tsx
@@ -53,10 +53,12 @@ const Documents = () => {
     // Simple refresh without disruptive re-renders - just re-fetch job data
     if (job_id && accessToken) {
       try {
+        // Add cache-busting param to jobPostId (if backend supports it)
+        const cacheBuster = `?t=${Date.now()}`;
         await dispatch(
           getJobPost({
             accessToken,
-            jobPostId: job_id as string,
+            jobPostId: job_id + cacheBuster,
           })
         ).unwrap();
       } catch (error) {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,5 @@
 /** @type {import('next').NextConfig} */
+
 const nextConfig = {
   images: {
     remotePatterns: [
@@ -13,6 +14,20 @@ const nextConfig = {
         pathname: '/**',
       },
     ],
+  },
+  async headers() {
+    return [
+      {
+        // Adjust the source to match your API route(s) for jobs and documents
+        source: '/api/(jobs|documents|jobPosts|documentsPerUser|document|jobPost)/:path*',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'no-store',
+          },
+        ],
+      },
+    ];
   },
 };
 


### PR DESCRIPTION
Fix: add cache-control and cache-busting query param.
In production the the documents in the Documents Tab in the Job Application modal are not refreshed after the document has been updated.
This PR should solve this issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved document refresh reliability by ensuring the latest job post data is always fetched.
* **Chores**
  * Updated server configuration to prevent caching for specific API routes, ensuring users receive the most up-to-date information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->