### PR TITLE
Refactor user documents page

### DIFF
--- a/app/(loggedin)/home/boards/[board_id]/documents/page.tsx
+++ b/app/(loggedin)/home/boards/[board_id]/documents/page.tsx
@@ -116,7 +116,13 @@ const BoardDocuments = () => {
     handleEditDocument,
     handleDeleteDocument,
     handleDownloadDocument,
-  } = useDocumentActions(boardDocuments, accessToken, handleDocumentsRefresh);
+    handleDocumentUpdate,
+  } = useDocumentActions(
+    boardDocuments,
+    accessToken,
+    handleDocumentsRefresh,
+    true
+  ); // Enable optimistic updates
 
   // Early return after all hooks are called
   if (!boardId) {
@@ -235,13 +241,12 @@ const BoardDocuments = () => {
         <EditDocumentModal
           isOpen={isEditModalOpen}
           documentToEdit={documentToEdit}
-          onEditSuccess={async () => {
-            // Close the modal first
+          onEditSuccess={async (updatedDocument) => {
             setIsEditModalOpen(false);
             setDocumentToEdit(null);
-
-            // Then refresh the documents
-            await handleDocumentsRefresh();
+            if (updatedDocument) {
+              await handleDocumentUpdate(updatedDocument);
+            }
           }}
           onClose={() => {
             setIsEditModalOpen(false);

--- a/app/(loggedin)/home/documents/page.tsx
+++ b/app/(loggedin)/home/documents/page.tsx
@@ -1,17 +1,16 @@
 'use client';
 
-import { toast } from 'react-toastify';
 import { useEffect, useState } from 'react';
 
 import { getUser } from '@/redux/user/userThunk';
+import { TITLE_MAX_LENGTH } from '@/data/constants';
+import useDocumentActions from '@/hooks/useDocumentActions';
 import { useAppDispatch, useAppSelector } from '@/redux/hooks';
-import { TITLE_MAX_LENGTH, FIXED_GRID_STYLES } from '@/data/constants';
+import DocumentGrid from '@/components/Documents/DocumentGrid';
+import { getDocumentsPerUser } from '@/redux/documents/documentsThunk';
+import DocumentFilterBar from '@/components/Documents/DocumentFilterBar';
+import type { CategoryCount } from '@/components/Documents/DocumentFilterBar';
 import EditDocumentModal from '@/components/Forms/AddDocument/EditDocumentModal';
-import DocumentCard from '@/components/HomePage/Kanban/Column/JobPosts/JobModal/JobDocuments/DocumentCard';
-import {
-  deleteDocument,
-  getDocumentsPerUser,
-} from '@/redux/documents/documentsThunk';
 import {
   selectUserDocuments,
   selectUserDocumentsStatus,
@@ -22,12 +21,8 @@ const UserDocuments = () => {
   const user = useAppSelector((state) => state.user);
 
   const userDocuments = useAppSelector(selectUserDocuments);
-  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const userDocumentsStatus = useAppSelector(selectUserDocumentsStatus);
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null); // null = All
-  const [documentToEdit, setDocumentToEdit] = useState<JobDocument | null>(
-    null
-  );
   const [uploaderInfo, setUploaderInfo] = useState<{
     lastName: string;
     firstName: string;
@@ -131,85 +126,16 @@ const UserDocuments = () => {
       )
     : enhancedDocuments;
 
-  const handleEditDocument = (document: JobDocument) => {
-    // Find the original document with the full title from userDocuments
-    const originalDocument = userDocuments.find(
-      (doc) => doc.id === document.id
-    );
-    // Use the original document if found, otherwise use the provided document
-    setDocumentToEdit(originalDocument || document);
-    setIsEditModalOpen(true);
-  };
-
-  const handleDeleteDocument = async (documentId: string) => {
-    try {
-      if (!accessToken) {
-        toast.error('Authentication required');
-        return;
-      }
-
-      // For user documents, always delete the document entirely from the database
-      // This will automatically detach it from all job applications and remove it completely
-      await dispatch(
-        deleteDocument({
-          documentId,
-          accessToken: accessToken as string,
-        })
-      ).unwrap();
-
-      toast.success('Document deleted successfully!');
-      await handleDocumentsRefresh();
-    } catch (error) {
-      console.error('Error deleting document:', error);
-      toast.error('Failed to delete document. Please try again.');
-    }
-  };
-
-  const handleDownloadDocument = async (jobDocument: JobDocument) => {
-    try {
-      if (!jobDocument.url) {
-        toast.error('Document URL not available');
-        return;
-      }
-
-      const newTab = window.open(
-        jobDocument.url,
-        '_blank',
-        'noopener,noreferrer'
-      );
-
-      if (!newTab || newTab.closed || typeof newTab.closed === 'undefined') {
-        // Fallback: Create a download link for popup blocker case
-        const link = document.createElement('a');
-        link.href = jobDocument.url;
-        link.download = jobDocument.title || 'document';
-        link.target = '_blank';
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
-        toast.success('Document download initiated');
-        return;
-      }
-
-      // Use a more robust approach with proper error handling and longer timeout
-      const checkTabStatus = setTimeout(() => {
-        try {
-          if (newTab && !newTab.closed) {
-            toast.success('Document opened in new tab');
-          } else {
-            toast.success('Document has been downloaded');
-          }
-        } catch (error) {
-          // Tab may be closed, cross-origin, or inaccessible
-          console.warn('Could not check tab status:', error);
-          toast.success('Document has been processed');
-        }
-      }, 1000);
-    } catch (error) {
-      console.error('Error opening document:', error);
-      toast.error('Failed to open document. Please try again.');
-    }
-  };
+  // Use the shared document actions hook - MUST be called before any conditional returns
+  const {
+    documentToEdit,
+    isEditModalOpen,
+    setDocumentToEdit,
+    setIsEditModalOpen,
+    handleEditDocument,
+    handleDeleteDocument,
+    handleDownloadDocument,
+  } = useDocumentActions(userDocuments, accessToken, handleDocumentsRefresh);
 
   if (userDocumentsStatus === 'loading') {
     return (
@@ -227,85 +153,13 @@ const UserDocuments = () => {
         </div>
       </div>
 
-      {/* Filter Bar - above the cards, full width, white bg */}
-      <div className="w-full bg-white pt-6 pb-2 px-6 border-b">
-        <div className="flex items-center gap-2">
-          {/* All filter */}
-          <div
-            className={`flex items-center gap-1 px-3 py-1 rounded-lg cursor-pointer font-medium text-sm transition ${
-              selectedCategory === null
-                ? 'bg-violet-100 text-violet-700 ring-2 ring-violet-300'
-                : 'bg-violet-50 text-violet-700 hover:bg-violet-100'
-            }`}
-            style={{ minWidth: 48 }}
-            onClick={() => setSelectedCategory(null)}
-            tabIndex={0}
-            role="button"
-            aria-pressed={selectedCategory === null}
-          >
-            <span>All</span>
-            <span className="ml-1 px-2 py-0.5 rounded bg-gray-200 text-gray-700 font-semibold text-xs">
-              {userDocuments.length}
-            </span>
-          </div>
-          {/* Category filters */}
-          {categoryCounts.map(({ category, count }) => {
-            // Color mapping for categories
-            const colorMap: Record<string, string> = {
-              Resume: 'bg-blue-100 text-blue-700 hover:bg-blue-200',
-              'Cover Letter': 'bg-green-100 text-green-700 hover:bg-green-200',
-              'Writing Sample':
-                'bg-orange-100 text-orange-700 hover:bg-orange-200',
-              Portfolio: 'bg-purple-100 text-purple-700 hover:bg-purple-200',
-              Recommendation: 'bg-pink-100 text-pink-700 hover:bg-pink-200',
-              'Job Post': 'bg-lime-100 text-lime-700 hover:bg-lime-200',
-              'Offer Letter': 'bg-amber-300 text-amber-800 hover:bg-amber-400',
-              Certification: 'bg-teal-100 text-teal-700 hover:bg-teal-200',
-              Other: 'bg-indigo-100 text-indigo-700 hover:bg-indigo-200',
-              Transcript: 'bg-red-100 text-red-700 hover:bg-red-200',
-              Uncategorized: 'bg-gray-100 text-gray-700 hover:bg-gray-200',
-            };
-            const selectedColorMap: Record<string, string> = {
-              Resume: 'bg-blue-100 text-blue-700 ring-2 ring-blue-300',
-              'Cover Letter':
-                'bg-green-100 text-green-700 ring-2 ring-green-300',
-              'Writing Sample':
-                'bg-orange-100 text-orange-700 ring-2 ring-orange-300',
-              Portfolio: 'bg-purple-100 text-purple-700 ring-2 ring-purple-300',
-              Recommendation: 'bg-pink-100 text-pink-700 ring-2 ring-pink-300',
-              'Job Post': 'bg-lime-100 text-lime-700 ring-2 ring-lime-300',
-              'Offer Letter':
-                'bg-amber-300 text-amber-800 ring-2 ring-amber-500',
-              Certification: 'bg-teal-100 text-teal-700 ring-2 ring-teal-300',
-              Other: 'bg-indigo-100 text-indigo-700 ring-2 ring-indigo-300',
-              Transcript: 'bg-red-100 text-red-700 ring-2 ring-red-300',
-              Uncategorized: 'bg-gray-100 text-gray-700 ring-2 ring-gray-300',
-            };
-            const colorClass =
-              selectedCategory === category
-                ? selectedColorMap[category] ||
-                  'bg-gray-100 text-gray-700 ring-2 ring-gray-300'
-                : colorMap[category] ||
-                  'bg-gray-100 text-gray-700 hover:bg-gray-200';
-            return (
-              <div
-                tabIndex={0}
-                role="button"
-                key={category}
-                style={{ minWidth: 48 }}
-                aria-pressed={selectedCategory === category}
-                onClick={() => setSelectedCategory(category)}
-                className={`flex items-center gap-1 px-3 py-1 rounded-lg cursor-pointer font-medium text-sm transition ${colorClass}`}
-              >
-                <span className="px-2 py-0.5 rounded bg-gray-200 text-gray-700 font-semibold text-xs">
-                  {count}
-                </span>
-                <span>{category}</span>
-              </div>
-            );
-          })}
-        </div>
-      </div>
+      {/* Filter Bar using the shared component */}
+      <DocumentFilterBar
+        categoryCounts={categoryCounts}
+        allCount={userDocuments.length}
+        selectedCategory={selectedCategory}
+        setSelectedCategory={setSelectedCategory}
+      />
 
       {userDocuments.length === 0 ? (
         <div className="flex-1 flex items-center justify-center">
@@ -320,19 +174,13 @@ const UserDocuments = () => {
           </p>
         </div>
       ) : (
-        <div className="flex-1 overflow-y-auto p-6">
-          <div style={FIXED_GRID_STYLES}>
-            {filteredDocuments.map((document) => (
-              <DocumentCard
-                key={document.id}
-                document={document}
-                onEdit={handleEditDocument}
-                onDelete={handleDeleteDocument}
-                onDownload={handleDownloadDocument}
-              />
-            ))}
-          </div>
-        </div>
+        <DocumentGrid
+          onEdit={handleEditDocument}
+          documents={filteredDocuments}
+          onDelete={handleDeleteDocument}
+          onDownload={handleDownloadDocument}
+          emptyMessage="No documents found for this category"
+        />
       )}
 
       {/* Edit Document Modal */}

--- a/app/(loggedin)/home/documents/page.tsx
+++ b/app/(loggedin)/home/documents/page.tsx
@@ -135,7 +135,13 @@ const UserDocuments = () => {
     handleEditDocument,
     handleDeleteDocument,
     handleDownloadDocument,
-  } = useDocumentActions(userDocuments, accessToken, handleDocumentsRefresh);
+    handleDocumentUpdate,
+  } = useDocumentActions(
+    userDocuments,
+    accessToken,
+    handleDocumentsRefresh,
+    true
+  ); // Enable optimistic updates
 
   if (userDocumentsStatus === 'loading') {
     return (
@@ -188,19 +194,11 @@ const UserDocuments = () => {
         <EditDocumentModal
           isOpen={isEditModalOpen}
           documentToEdit={documentToEdit}
-          onEditSuccess={async () => {
-            // Close the modal first
+          onEditSuccess={async (updatedDocument) => {
             setIsEditModalOpen(false);
             setDocumentToEdit(null);
-
-            // Then refresh the documents
-            if (accessToken) {
-              try {
-                // Directly dispatch the action to ensure it updates the Redux store
-                await dispatch(getDocumentsPerUser(accessToken));
-              } catch (error) {
-                console.error('Failed to refresh documents after edit:', error);
-              }
+            if (updatedDocument) {
+              await handleDocumentUpdate(updatedDocument);
             }
           }}
           onClose={() => {

--- a/components/Forms/AddDocument/EditDocumentModal.tsx
+++ b/components/Forms/AddDocument/EditDocumentModal.tsx
@@ -14,6 +14,13 @@ import {
   SelectTrigger,
 } from '@/components/ui/select';
 
+interface EditDocumentsProps {
+  isOpen: boolean;
+  onClose: () => void;
+  documentToEdit: JobDocument;
+  onEditSuccess: (updatedDocument?: JobDocument) => void | Promise<void>;
+}
+
 const EditDocumentModal = ({
   isOpen,
   onClose,
@@ -46,7 +53,7 @@ const EditDocumentModal = ({
     }
     setIsSaving(true);
     try {
-      await dispatch(
+      const result = await dispatch(
         updateDocument({
           category,
           description,
@@ -55,8 +62,9 @@ const EditDocumentModal = ({
           documentId: documentToEdit.id,
         })
       ).unwrap();
-      toast.success('Document updated successfully!');
-      onEditSuccess();
+
+      // Pass the updated document to the success callback
+      onEditSuccess(result);
     } catch (error) {
       console.error('Error updating document:', error);
       toast.error('Failed to update document. Please try again.');

--- a/hooks/useDocumentActions.ts
+++ b/hooks/useDocumentActions.ts
@@ -1,12 +1,17 @@
 import { useState } from 'react';
 import { toast } from 'react-toastify';
 import { useAppDispatch } from '@/redux/hooks';
-import { deleteDocument } from '@/redux/documents/documentsThunk';
+import {
+  deleteDocument,
+  updateDocument,
+} from '@/redux/documents/documentsThunk';
+import { updateDocumentInState } from '@/redux/documents/documentsSlice';
 
 export const useDocumentActions = (
   documents: JobDocument[],
   accessToken: string | null,
-  refreshDocuments: () => Promise<void>
+  refreshDocuments: () => Promise<void>,
+  optimisticUpdates: boolean = true // New parameter for controlling behavior
 ) => {
   const dispatch = useAppDispatch();
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
@@ -15,10 +20,20 @@ export const useDocumentActions = (
   );
 
   const handleEditDocument = (document: JobDocument) => {
-    // Find the original document with the full title
     const originalDocument = documents.find((doc) => doc.id === document.id);
     setDocumentToEdit(originalDocument || document);
     setIsEditModalOpen(true);
+  };
+
+  const handleDocumentUpdate = async (updatedDocument: JobDocument) => {
+    if (optimisticUpdates) {
+      // Optimistic update: immediately update Redux state
+      dispatch(updateDocumentInState(updatedDocument));
+      toast.success('Document updated successfully!');
+    } else {
+      // Traditional approach: full refresh
+      await refreshDocuments();
+    }
   };
 
   const handleDeleteDocument = async (documentId: string) => {
@@ -92,10 +107,11 @@ export const useDocumentActions = (
     documentToEdit,
     isEditModalOpen,
     setDocumentToEdit,
-    handleEditDocument,
     setIsEditModalOpen,
+    handleEditDocument,
     handleDeleteDocument,
     handleDownloadDocument,
+    handleDocumentUpdate,
   };
 };
 

--- a/hooks/useDocumentActions.ts
+++ b/hooks/useDocumentActions.ts
@@ -26,13 +26,40 @@ export const useDocumentActions = (
   };
 
   const handleDocumentUpdate = async (updatedDocument: JobDocument) => {
-    if (optimisticUpdates) {
-      // Optimistic update: immediately update Redux state
-      dispatch(updateDocumentInState(updatedDocument));
+    try {
+      if (!accessToken) {
+        toast.error('Authentication required');
+        return;
+      }
+
+      if (optimisticUpdates) {
+        // Optimistic update: immediately update Redux state
+        dispatch(updateDocumentInState(updatedDocument));
+      }
+
+      // Always make the API call to persist changes
+      await dispatch(
+        updateDocument({
+          documentId: updatedDocument.id,
+          title: updatedDocument.title,
+          category: updatedDocument.category,
+          description: updatedDocument.description,
+          accessToken,
+        })
+      ).unwrap();
+
+      if (!optimisticUpdates) {
+        await refreshDocuments();
+      }
+
       toast.success('Document updated successfully!');
-    } else {
-      // Traditional approach: full refresh
-      await refreshDocuments();
+    } catch (error) {
+      if (optimisticUpdates) {
+        // Revert optimistic update on failure
+        await refreshDocuments();
+      }
+      console.error('Error updating document:', error);
+      toast.error('Failed to update document. Please try again.');
     }
   };
 

--- a/redux/documents/documentsSlice.ts
+++ b/redux/documents/documentsSlice.ts
@@ -36,8 +36,16 @@ const documentsSlice = createSlice({
   name: 'documents',
   initialState,
   reducers: {
-    updateDocumentInState: (state, action) => {
+    updateDocumentInState: (state, action: { payload: JobDocument }) => {
       const updatedDoc = action.payload;
+
+      // Update in documents
+      const docIndex = state.documents.findIndex(
+        (doc) => doc.id === updatedDoc.id
+      );
+      if (docIndex !== -1) {
+        state.documents[docIndex] = updatedDoc;
+      }
 
       // Update in userDocuments
       const userIndex = state.userDocuments.findIndex(

--- a/redux/documents/documentsSlice.ts
+++ b/redux/documents/documentsSlice.ts
@@ -35,7 +35,27 @@ const initialState: DocumentState = {
 const documentsSlice = createSlice({
   name: 'documents',
   initialState,
-  reducers: {},
+  reducers: {
+    updateDocumentInState: (state, action) => {
+      const updatedDoc = action.payload;
+
+      // Update in userDocuments
+      const userIndex = state.userDocuments.findIndex(
+        (doc) => doc.id === updatedDoc.id
+      );
+      if (userIndex !== -1) {
+        state.userDocuments[userIndex] = updatedDoc;
+      }
+
+      // Update in boardDocuments
+      const boardIndex = state.boardDocuments.findIndex(
+        (doc) => doc.id === updatedDoc.id
+      );
+      if (boardIndex !== -1) {
+        state.boardDocuments[boardIndex] = updatedDoc;
+      }
+    },
+  },
   extraReducers: (builder) => {
     builder
       .addCase(getDocument.pending, (state) => {
@@ -174,3 +194,4 @@ export const selectBoardDocuments = (state: RootState) =>
   state.documents.boardDocuments;
 export const selectBoardDocumentsStatus = (state: RootState) =>
   state.documents.boardDocumentsStatus;
+export const { updateDocumentInState } = documentsSlice.actions;


### PR DESCRIPTION
Refactor user's and board's documents page with common components and optimistic update for refreshing only the document changed.
Fix some bug in API persistence and type safety.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optimistic updates are now enabled when editing documents, providing immediate feedback in the UI after changes.
  * Document filtering and listing interfaces have been improved with reusable components for a more streamlined experience.

* **Refactor**
  * Document management logic has been centralized, reducing duplication and improving maintainability.
  * Toast notifications and error handling for document actions are now handled consistently.

* **Bug Fixes**
  * Editing a document now updates only the relevant document in the list, avoiding unnecessary full refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->