### PR TITLE
Use POST for refresh token

### DIFF
--- a/api/client.ts
+++ b/api/client.ts
@@ -53,7 +53,7 @@ client.interceptors.response.use(
               }
             );
 
-            if (refreshResponse.status === 200) {
+            if (refreshResponse.status === 200 || refreshResponse.status === 201) {
               const {
                 accessToken: newAccessToken,
                 refreshToken: newRefreshToken,

--- a/api/client.ts
+++ b/api/client.ts
@@ -45,8 +45,9 @@ client.interceptors.response.use(
       if (refreshToken) {
         refreshPromise = (async () => {
           try {
-            const refreshResponse = await axios.get(
+            const refreshResponse = await axios.post(
               `${process.env.NEXT_PUBLIC_API_URL}/auth/refresh`,
+              null,
               {
                 headers: { Authorization: `Bearer ${refreshToken}` },
               }

--- a/redux/auth/refreshAccessTokenThunk.ts
+++ b/redux/auth/refreshAccessTokenThunk.ts
@@ -7,7 +7,7 @@ export const refreshAccessToken = createAsyncThunk(
   'auth/refreshAccessToken',
   async (refreshToken: string, thunkAPI) => {
     try {
-      const response = await client.get('/auth/refresh', {
+      const response = await client.post('/auth/refresh', null, {
         headers: {
           Authorization: `Bearer ${refreshToken}`,
         },

--- a/redux/auth/refreshAccessTokenThunk.ts
+++ b/redux/auth/refreshAccessTokenThunk.ts
@@ -14,7 +14,7 @@ export const refreshAccessToken = createAsyncThunk(
       });
       const data = response.data;
 
-      if (response.status === 200) {
+      if (response.status === 200 || response.status === 201) {
         localStorage.setItem('accessToken', data.accessToken);
         localStorage.setItem('refreshToken', data.refreshToken);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token refresh reliability by changing the request method and expanding accepted response statuses. This ensures smoother authentication and reduces potential login interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->