### PR TITLE
Fix timezoneoffset

### DIFF
--- a/app/(landing)/layout.tsx
+++ b/app/(landing)/layout.tsx
@@ -2,7 +2,7 @@
 
 const LandingLayout = ({ children }: { children: React.ReactNode }) => {
   return (
-    <main className="h-full overflow-auto">
+    <main className="h-full">
       <div className="mx-auto h-full w-full">{children}</div>
     </main>
   );

--- a/app/(landing)/layout.tsx
+++ b/app/(landing)/layout.tsx
@@ -2,7 +2,7 @@
 
 const LandingLayout = ({ children }: { children: React.ReactNode }) => {
   return (
-    <main className="h-full">
+    <main className="h-full min-h-screen">
       <div className="mx-auto h-full w-full">{children}</div>
     </main>
   );

--- a/app/(landing)/page.tsx
+++ b/app/(landing)/page.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import ContentSection from '@/components/LandingPage/ContentSection';
-import Footer from '@/components/LandingPage/Footer';
-import HeroSection from '@/components/LandingPage/HeroSection';
-import Navbar from '@/components/LandingPage/Navbar';
 import { Fragment } from 'react';
+
+import Footer from '@/components/LandingPage/Footer';
+import Navbar from '@/components/LandingPage/Navbar';
+import HeroSection from '@/components/LandingPage/HeroSection';
+import ContentSection from '@/components/LandingPage/ContentSection';
 
 const Home = () => {
   return (

--- a/app/(landing)/page.tsx
+++ b/app/(landing)/page.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { Fragment } from 'react';
-
 import Footer from '@/components/LandingPage/Footer';
 import Navbar from '@/components/LandingPage/Navbar';
 import HeroSection from '@/components/LandingPage/HeroSection';
@@ -9,7 +7,7 @@ import ContentSection from '@/components/LandingPage/ContentSection';
 
 const Home = () => {
   return (
-    <Fragment>
+    <>
       <Navbar />
       <HeroSection />
       <ContentSection
@@ -28,7 +26,7 @@ const Home = () => {
         description="Add your job search contacts."
       />
       <Footer />
-    </Fragment>
+    </>
   );
 };
 

--- a/app/(loggedin)/home/settings/page.tsx
+++ b/app/(loggedin)/home/settings/page.tsx
@@ -91,14 +91,14 @@ const Settings = () => {
         daily: dailyDigest
           ? {
               time: '09:00' as const,
-              timezoneOffset: -timezoneOffset,
+              timezoneOffset: timezoneOffset,
             }
           : null,
         weekly: weeklyDigest
           ? {
               time: '09:00' as const,
               dayOfWeek: 'MONDAY' as const,
-              timezoneOffset: -timezoneOffset,
+              timezoneOffset: timezoneOffset,
             }
           : null,
       };

--- a/components/LandingPage/ContentSection.tsx
+++ b/components/LandingPage/ContentSection.tsx
@@ -14,16 +14,16 @@ interface ContentSectionProps {
 const sectionColors: Record<SectionId, string> = {
   applications:
     'from-blue-100 via-blue-50 to-white dark:from-blue-900 dark:via-gray-900 dark:to-black',
-  documents:
-    'from-purple-100 via-pink-50 to-white dark:from-purple-900 dark:via-gray-900 dark:to-black',
   contacts:
     'from-green-100 via-green-50 to-white dark:from-green-900 dark:via-gray-900 dark:to-black',
+  documents:
+    'from-purple-100 via-pink-50 to-white dark:from-purple-900 dark:via-gray-900 dark:to-black',
 };
 
 const sectionImages: Record<SectionId, string> = {
-  applications: '/images/Add_Job.png',
-  documents: '/images/Documents.png',
   contacts: '/images/Contacts.png',
+  documents: '/images/Documents.png',
+  applications: '/images/Add_Job.png',
 };
 
 const sectionIcons: Record<SectionId, JSX.Element> = {

--- a/components/LandingPage/ContentSection.tsx
+++ b/components/LandingPage/ContentSection.tsx
@@ -11,20 +11,20 @@ interface ContentSectionProps {
   description: string;
 }
 
-const sectionColors: Record<SectionId, string> = {
+const sectionColors = {
   applications:
     'from-blue-100 via-blue-50 to-white dark:from-blue-900 dark:via-gray-900 dark:to-black',
   contacts:
     'from-green-100 via-green-50 to-white dark:from-green-900 dark:via-gray-900 dark:to-black',
   documents:
     'from-purple-100 via-pink-50 to-white dark:from-purple-900 dark:via-gray-900 dark:to-black',
-};
+} satisfies Record<SectionId, string>;
 
-const sectionImages: Record<SectionId, string> = {
+const sectionImages = {
   contacts: '/images/Contacts.png',
   documents: '/images/Documents.png',
   applications: '/images/Add_Job.png',
-};
+} satisfies Record<SectionId, string>;
 
 const sectionIcons: Record<SectionId, JSX.Element> = {
   applications: (
@@ -77,20 +77,20 @@ const sectionIcons: Record<SectionId, JSX.Element> = {
   ),
 };
 
-const sectionParagraphs: Record<SectionId, string> = {
+const sectionParagraphs = {
   applications:
     'Bring all your job search details together—no more scattered spreadsheets or sticky notes. Track every opportunity, from company data and job descriptions to interview dates, contacts, and more. Your entire job search, organized and accessible in one place.',
   documents:
     'Easily upload and manage your resumes, cover letters, and supporting documents. Attach them to jobs, activities, or contacts, so you always have the right file at your fingertips when you need it most.',
   contacts:
     'Keep track of everyone you meet along your journey—recruiters, interviewers, and networking connections. Store contact info, add notes, and never lose touch with the people who can help you land your next role.',
-};
+} satisfies Record<SectionId, string>;
 
 const ContentSection = ({ name, description, id }: ContentSectionProps) => {
-  const colorClass = id ? sectionColors[id] : 'from-gray-100 to-white';
   const icon = id ? sectionIcons[id] : null;
   const paragraph = id ? sectionParagraphs[id] : '';
   const imageSrc = id ? sectionImages[id] : '/images/JobsBoard.png';
+  const colorClass = id ? sectionColors[id] : 'from-gray-100 to-white';
 
   return (
     <section

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,39 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.192.0] - 2025-08-24
+
+### Bug Fixes - 2025-08-24
+
+- **Fixed critical error message display bug**: Resolved issue where ApiError objects were being cast to string, causing "[object Object]" error messages
+
+  - **Issue**: Redux rejected actions with `rejectWithValue(ApiError)` were being cast to string, resulting in unhelpful "[object Object]" error messages
+  - **Solution**: Properly extract `message` property from ApiError object using type-safe property access
+  - **Impact**: Users now see actual error messages like "Network error" instead of "[object Object]"
+  - **Files**: `redux/notifications/notificationsSlice.ts`
+
+- **Fixed timezone offset calculation**: Corrected timezone offset sign for proper notification scheduling
+
+  - **Issue**: `getTimezoneOffset()` returns minutes behind UTC, but backend expects minutes ahead of UTC
+  - **Solution**: Negate `getTimezoneOffset()` value before sending to backend
+  - **Impact**: Notifications now scheduled at correct local time across all timezones
+  - **Files**: `app/(loggedin)/home/settings/page.tsx`
+
+- **Implemented dirty flag pattern for notification toggles**: Prevented initial API fetch from overwriting user changes
+
+  - **Issue**: Users could lose toggle changes if they interacted with UI before initial API call completed
+  - **Solution**: Added `notificationsDirty` flag to gate state synchronization and preserve user input
+  - **Impact**: User toggle changes are now preserved during API loading states
+  - **Files**: `app/(loggedin)/home/settings/page.tsx`
+
+- Remove a second scroll bar on the landing page.
+
+### Files Changed
+
+- app/(landing)/layout.tsx
+- app/(loggedin)/home/settings/page.tsx
+- redux/notifications/notificationsSlice.ts
+
 ## [0.191.0] - 2025-08-23
 
 ### CodeRabbit Implementation - Type Safety and Error Handling Improvements

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.192.0] - 2025-08-24
 
-### Bug Fixes - 2025-08-24
+### Fixed - 2025-08-24
 
 - **Fixed critical error message display bug**: Resolved issue where ApiError objects were being cast to string, causing "[object Object]" error messages
 
@@ -16,9 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Fixed timezone offset calculation**: Corrected timezone offset sign for proper notification scheduling
 
-  - **Issue**: `getTimezoneOffset()` returns minutes behind UTC, but backend expects minutes ahead of UTC
-  - **Solution**: Negate `getTimezoneOffset()` value before sending to backend
-  - **Impact**: Notifications now scheduled at correct local time across all timezones
+  - **Issue**: `getTimezoneOffset()` was negated before sending, flipping the sign relative to backend expectations
+  - **Solution**: Send the raw `getTimezoneOffset()` value (no negation)
+  - **Impact**: Notifications are scheduled at the correct local time across all timezones
   - **Files**: `app/(loggedin)/home/settings/page.tsx`
 
 - **Implemented dirty flag pattern for notification toggles**: Prevented initial API fetch from overwriting user changes
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Impact**: User toggle changes are now preserved during API loading states
   - **Files**: `app/(loggedin)/home/settings/page.tsx`
 
-- Remove a second scroll bar on the landing page.
+- Removed a second scroll bar on the landing page.
 
 ### Files Changed
 
@@ -2426,8 +2426,10 @@ _All changes maintain backward compatibility and enhance user experience with im
 
 <!-- Version comparison links -->
 
-[0.189.0]: https://github.com/Hombre2014/job-tracker-frontend/compare/v0.188.0...v0.189.0
+[0.192.0]: https://github.com/Hombre2014/job-tracker-frontend/compare/v0.191.0...v0.192.0
+[0.191.0]: https://github.com/Hombre2014/job-tracker-frontend/compare/v0.190.0...v0.191.0
 [0.190.0]: https://github.com/Hombre2014/job-tracker-frontend/compare/v0.189.0...v0.190.0
+[0.189.0]: https://github.com/Hombre2014/job-tracker-frontend/compare/v0.188.0...v0.189.0
 [0.186.0]: https://github.com/Hombre2014/job-tracker-frontend/compare/v0.185.0...v0.186.0
 [0.185.0]: https://github.com/Hombre2014/job-tracker-frontend/compare/v0.184.0...v0.185.0
 [0.184.0]: https://github.com/Hombre2014/job-tracker-frontend/compare/v0.182.0...v0.184.0

--- a/redux/notifications/notificationsSlice.ts
+++ b/redux/notifications/notificationsSlice.ts
@@ -1,8 +1,8 @@
 import { createSlice, PayloadAction, isAnyOf } from '@reduxjs/toolkit';
 import {
   getBothNotifications,
-  createUpdateDeleteNotifications,
   NotificationsResponse,
+  createUpdateDeleteNotifications,
 } from './notificationsThunk';
 
 interface NotificationsState {
@@ -14,9 +14,9 @@ interface NotificationsState {
 
 const initialState: NotificationsState = {
   daily: null,
+  error: null,
   weekly: null,
   loading: false,
-  error: null,
 };
 
 const notificationsSlice = createSlice({
@@ -31,7 +31,10 @@ const notificationsSlice = createSlice({
     builder
       // pending matcher
       .addMatcher(
-        isAnyOf(getBothNotifications.pending, createUpdateDeleteNotifications.pending),
+        isAnyOf(
+          getBothNotifications.pending,
+          createUpdateDeleteNotifications.pending
+        ),
         (state) => {
           state.loading = true;
           state.error = null;
@@ -39,7 +42,10 @@ const notificationsSlice = createSlice({
       )
       // fulfilled matcher
       .addMatcher(
-        isAnyOf(getBothNotifications.fulfilled, createUpdateDeleteNotifications.fulfilled),
+        isAnyOf(
+          getBothNotifications.fulfilled,
+          createUpdateDeleteNotifications.fulfilled
+        ),
         (state, action: PayloadAction<NotificationsResponse>) => {
           state.loading = false;
           state.daily = action.payload.daily;
@@ -48,7 +54,10 @@ const notificationsSlice = createSlice({
       )
       // rejected matcher
       .addMatcher(
-        isAnyOf(getBothNotifications.rejected, createUpdateDeleteNotifications.rejected),
+        isAnyOf(
+          getBothNotifications.rejected,
+          createUpdateDeleteNotifications.rejected
+        ),
         (state, action) => {
           state.loading = false;
           const fallback = (action as any)?.error?.message ?? 'Unknown error';

--- a/redux/notifications/notificationsSlice.ts
+++ b/redux/notifications/notificationsSlice.ts
@@ -60,8 +60,9 @@ const notificationsSlice = createSlice({
         ),
         (state, action) => {
           state.loading = false;
-          const fallback = (action as any)?.error?.message ?? 'Unknown error';
-          state.error = (action.payload as string | undefined) ?? fallback;
+          const fallback = action.error?.message ?? 'Unknown error';
+          const payloadMsg = (action.payload as { message?: string } | undefined)?.message;
+          state.error = payloadMsg ?? fallback;
         }
       );
   },

--- a/redux/notifications/notificationsThunk.ts
+++ b/redux/notifications/notificationsThunk.ts
@@ -29,13 +29,13 @@ export type DayOfWeek =
 
 export interface NotificationSettings {
   id?: string;
-  time: `${number}:${number}`; // "HH:MM" format
   updatedAt?: string;
   createdAt?: string;
   timezoneOffset: number; // -840 to 720
   scheduledTime?: string;
   type: 'DAILY' | 'WEEKLY';
   deletedAt?: string | null;
+  time: `${number}:${number}`; // "HH:MM" format
   dayOfWeek?: DayOfWeek;
 }
 
@@ -71,10 +71,13 @@ export const getBothNotifications = createAsyncThunk<
       return rejectWithValue({ message: 'Missing access token' });
     }
     try {
-      const res = await client.get<NotificationsResponse>('/notifications/report', {
-        headers: { Authorization: `Bearer ${accessToken}` },
-        signal,
-      });
+      const res = await client.get<NotificationsResponse>(
+        '/notifications/report',
+        {
+          headers: { Authorization: `Bearer ${accessToken}` },
+          signal,
+        }
+      );
       // Graceful fallback if backend returns empty/204
       return res?.data ?? { daily: null, weekly: null };
     } catch (err: unknown) {


### PR DESCRIPTION
The `timezoneOffset` was used with negative "-" sign, which caused wrong time offset calcuatiuon.
The second scrollbar on the landing page have been removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Notifications now schedule correctly in users’ local time.
  - Preserved user changes to notification toggles during loading.
  - Removed an extra scrollbar on the landing page for smoother scrolling.
  - Error messages now display actual error text (e.g., network errors) instead of generic messages.

- Documentation
  - Added version 0.192.0 changelog entries summarizing these fixes.

- Refactor
  - Internal reorganizations and formatting with no user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->