### PR TITLE
fix: remove the data download link

### DIFF
--- a/app/(loggedin)/home/settings/page.tsx
+++ b/app/(loggedin)/home/settings/page.tsx
@@ -443,13 +443,13 @@ const Settings = () => {
                   </label>
                 </div>
                 <div className="flex flex-col w-fit mt-6">
-                  <Button
+                  {/* <Button
                     variant="ghost"
                     onClick={handleDownloadData}
                     className="justify-start text-gray-600 dark:text-slate-400"
                   >
                     Download my data
-                  </Button>
+                  </Button> */}
                   <Button
                     variant="ghost"
                     onClick={handleDeleteAccount}


### PR DESCRIPTION
The link for downloading my data has been commented out, until the functionality is implemented on the back end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Temporarily removed the “Download my data” button from the Settings page. The download option is no longer visible, while all other settings and behaviors remain unchanged. This is a UI-only adjustment with no impact on existing preferences or navigation. If you previously used data export, note that this option is currently unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->